### PR TITLE
chore: refresh ACAGi single-file messaging

### DIFF
--- a/ACAGi.py
+++ b/ACAGi.py
@@ -1,24 +1,17 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-Agent Virtual Desktop — Codex-Terminal (All-in-One)
-- Virtual Desktop canvas (bright blue), draggable chat/terminal card
-- Local-first Chat (Ollama-only) + OCR/Vision pipeline
-- Dataset persistence (JSONL + embeddings) + user-memory (lightweight)
-- **Codex Rust CLI bridge for Windows**:
-    • Download/verify/launch Codex CLI
-    • Mirror CMD output (snapshots)
-    • Inject text to CMD
-    • **Press Enter reliably** (WriteConsoleInputW + SendInput fallback)
-    • Start/Stop/Show/Hide controls
-    • Tri-state LED (red/yellow/green) for bridge health
+"""ACAGi — unified single-file integration for the autonomous desktop stack.
 
-Requires: PySide6>=6.6, requests, Pillow (optional), local ollama, Windows 10+ for bridge.
+This module is the authoritative integration point: the virtual desktop, chat,
+memory, bridge, and safety subsystems previously maintained as separate scripts
+are now embedded here unless a component is explicitly documented elsewhere.
+Requirements: PySide6>=6.6, requests, Pillow (optional), local ollama, and
+Windows 10+ for the bridge runtime.
 """
 
 from __future__ import annotations
 
-# --- DPI policy MUST be set before QApplication is created ---
+# --- Single-file ACAGi sets DPI policy before QApplication instantiation ---
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtCore import Qt
 
@@ -64,7 +57,7 @@ from pathlib import Path
 from typing import Any, Callable, Deque, Dict, List, Optional, Sequence, Set, Tuple
 import token_budget
 
-# Optional deps
+# Optional deps remain co-located within this single-script stack
 try:
     import requests  # type: ignore
 except Exception:
@@ -193,7 +186,7 @@ def install_global_exception_handler(logger: Optional[logging.Logger] = None):
 
     def _hook(exc_type, exc, tb):
         shared_logger.error(
-            "Unhandled exception in Codex Terminal",
+            "Unhandled exception in ACAGi",
             exc_info=(exc_type, exc, tb),
         )
         for handler in shared_logger.handlers:
@@ -5487,7 +5480,7 @@ class TerminalDesktopCanvas(VirtualCanvas):
         self._create_text_file("New Python File", ".py", "#!/usr/bin/env python3\n\n\"\"\"New script.\"\"\"\n\n")
 
     def _new_powershell_desktop(self) -> None:
-        self._create_text_file("New PowerShell Script", ".ps1", "Write-Host 'Hello from Codex Terminal'\n")
+        self._create_text_file("New PowerShell Script", ".ps1", "Write-Host 'Hello from ACAGi'\n")
 
     def _new_zip_desktop(self) -> None:
         try:
@@ -6252,7 +6245,7 @@ def locate_styles_json() -> str:
 def main():
     shared_logger = configure_shared_logger()
     install_global_exception_handler(shared_logger)
-    shared_logger.info("Codex Terminal starting up (pid=%s)", os.getpid())
+    shared_logger.info("ACAGi starting up (pid=%s)", os.getpid())
     for handler in shared_logger.handlers:
         try:
             handler.flush()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.1] - 2025-10-02
+### Changed
+- Clarified ACAGi's single-file positioning in the module docstring and refreshed status/error messaging to use the ACAGi name.
+
 ## [0.1.0] - 2025-10-01
 ### Added
 - Initial governance scaffold including `AGENT.md`, memory structures, and session logging template.

--- a/logs/session_2025-10-02.md
+++ b/logs/session_2025-10-02.md
@@ -1,0 +1,19 @@
+# Session Log — 2025-10-02
+
+## Objective
+- Refresh ACAGi's branding and guidance so the single-file integration point is clearly documented and status logs reference ACAGi instead of the legacy Codex Terminal name.
+
+## Context
+- Reviewed AGENT.md, codex memory, and the logic inbox to confirm governance requirements for verbose documentation, session logging, and changelog updates.
+- Observed that ACAGi.py still opened with a Codex Terminal oriented docstring and contained crash/log messages referencing the retired name.
+
+## Actions
+- Replaced the module docstring with language that frames ACAGi as the authoritative one-file integration location for embedded subsystems.
+- Updated top-of-file inline comments to emphasize the single-script mandate while retaining DPI setup notes.
+- Refreshed status and error strings so user-facing crash logs and bootstrap telemetry refer to ACAGi; adjusted bundled PowerShell template output accordingly.
+- Planned to document the branding refresh in CHANGELOG.md and run `python -m compileall ACAGi.py` to validate syntax.
+
+## Suggested Next Coding Steps
+- Internal prompt: "Ensure ACAGi.py consistently presents itself as the single-entry module by updating documentation and status strings, then confirm syntax integrity via compileall."
+- Verify other documentation (e.g., Dev_Logic references) for lingering Codex Terminal branding during subsequent passes.
+- Progress pending logic inbox items on sentinel troubleshooting and Dev Logic templates when schedule allows.


### PR DESCRIPTION
## Summary
- update the ACAGi module docstring and top-of-file comments to emphasize that the project now lives as a single-script integration point
- rebrand crash logging, startup telemetry, and bundled script templates from “Codex Terminal” to “ACAGi”
- record the session context in the daily log and document the branding refresh in the changelog

## Testing
- `python -m compileall ACAGi.py`

## Risk
- Low; changes are limited to documentation strings, log messages, and supporting governance records.

## Next Steps
- Sweep ancillary design docs and Dev_Logic references for lingering Codex Terminal branding during future passes.


------
https://chatgpt.com/codex/tasks/task_e_68dd9bb7eadc8328854c631c9d1fe8c1