### PR TITLE
Refactor optional dependency handling for requests and Pillow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.2] - 2025-10-02
+### Changed
+- Refactored optional dependency handling so `requests` and Pillow are imported normally while runtime capability checks manage warnings and graceful degradation.
+
 ## [0.1.1] - 2025-10-02
 ### Changed
 - Clarified ACAGi's single-file positioning in the module docstring and refreshed status/error messaging to use the ACAGi name.

--- a/logs/session_2025-10-01.md
+++ b/logs/session_2025-10-01.md
@@ -27,3 +27,37 @@ Set up foundational governance scaffolding for the ACAGi Codex repository, ensur
 - Formalize Sentinel troubleshooting runbook per inbox item 2025-10-01-001.
 - Draft Dev Logic proposal template and store in `Dev_Logic/`.
 - Implement schema validation tests for memory artifacts.
+
+---
+## Session Update — 2025-10-01 (Runtime optional-dependency refactor)
+
+### Objective and Sub-goals
+- Primary objective: Convert the `requests` and `Pillow` imports in `ACAGi.py` into unconditional top-level imports while preserving optional behavior through runtime capability probes.
+- Sub-goals:
+  - Design helper utilities that encapsulate optional dependency availability checks and surface user-facing warnings at call-time.
+  - Ensure existing workflows for network fetches and image manipulation degrade gracefully when dependencies are absent.
+  - Run `python -m compileall ACAGi.py` alongside any documented lint/test commands to confirm structural integrity after refactor.
+
+### Context Review
+- Repository currently tracks branch `work` without a configured `origin` remote; `git fetch --all` is inapplicable at this time.
+- `ACAGi.py` presently assigns `requests = None` and `PIL_AVAILABLE = False` inside try/except guards, and several UI warnings rely on these module-level sentinels.
+- Pending logic inbox items 2025-10-01-001 and 2025-10-01-002 remain unresolved; this session focuses exclusively on the optional dependency refactor.
+
+### File-Scoped Notes
+- `ACAGi.py`: Lines surrounding the optional dependency imports (currently near the module prologue) require refactoring to remove import-time guards and introduce runtime helpers for warning emission.
+
+### Suggested Next Coding Steps
+1. Draft helper functions (e.g., `has_requests()` / `ensure_requests_available()`) that cache availability checks and raise or warn when invoked without installed dependencies; incorporate verbose docstrings per repository standards.
+2. Replace existing import-time fallback variables with calls to the helpers at each usage site, updating warning messages to trigger from the new runtime checks.
+3. Execute `python -m compileall ACAGi.py` and review the repository for additional lint/test scripts, running them if present, documenting outcomes for the commit and PR narrative.
+
+### Actions Completed
+- Introduced cached optional dependency helpers in `ACAGi.py` and replaced previous sentinel checks for `requests` and Pillow with runtime probes and targeted warnings.
+- Updated clipboard and attachment flows to surface Pillow availability issues through UI alerts, and refreshed Ollama client messaging to reuse the new helpers.
+- Recorded the refactor in `CHANGELOG.md` and captured the runtime dependency lesson in `memory/codex_memory.json`.
+
+### Validation Notes
+- Ran `python -m compileall ACAGi.py` to ensure the module compiles after the import refactor.
+
+### Follow-ups
+- Monitor future refactors for additional optional dependencies that should share the helper utilities.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -11,6 +11,11 @@
       "title": "Session Logging Discipline",
       "summary": "Every working session must produce a log in logs/session_<date>.md capturing objectives, context, and follow-up prompts.",
       "applies_to": "workflow"
+    },
+    {
+      "title": "Runtime Optional Dependency Checks",
+      "summary": "Handle optional libraries by importing them normally and relying on runtime capability helpers to emit user-facing warnings when dependencies are missing.",
+      "applies_to": "python-optional-deps"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- add cached runtime helpers in `ACAGi.py` to resolve optional dependencies without guarded imports
- update Ollama HTTP flows and image clipboard/attachment handling to surface capability warnings via the new helpers
- document the dependency refactor in the changelog and memory ledger for future sessions

## Testing
- python -m compileall ACAGi.py

## Risk
- Low; updates concentrate on optional dependency pathways and associated user messaging.

## Next Steps
- Apply the helper utilities to any additional optional integrations introduced later.


------
https://chatgpt.com/codex/tasks/task_e_68dda070f6188328970ea9c9b345cb7c