### PR TITLE
refactor: inline Dev Logic subsystems into acagi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.3] - 2025-10-03
+### Changed
+- Inlined task persistence, event bus, UI, error console, background engines, and repository reference helper directly into `ACAGi.py`, preserving existing behavior with new section headers for maintainability.
+- Updated governance utilities by validating the logic inbox and ensuring dependency-aware multimedia and OpenGL guards live within the monolithic file.
+
 ## [0.1.2] - 2025-10-02
 ### Changed
 - Refactored optional dependency handling so `requests` and Pillow are imported normally while runtime capability checks manage warnings and graceful degradation.

--- a/logs/session_2025-10-03.md
+++ b/logs/session_2025-10-03.md
@@ -1,0 +1,45 @@
+# Session Log – 2025-10-03
+
+## Objective
+- Inline task, error handling, background, and repository helper subsystems into `ACAGi.py` while preserving behavior.
+- Remove now-redundant intra-package imports and reorganize `ACAGi.py` with clear section headers.
+- Run project tests (via `tools/manage_tests.py` or equivalent) to validate the monolithic configuration.
+
+## Context Review
+- Reviewed `AGENT.md` v0.1.0 for operational directives, emphasizing verbose narration and documentation updates.
+- Consulted `memory/codex_memory.json` for stable lessons (verbose implementations, logging discipline, optional dependency policy).
+- Checked `memory/logic_inbox.jsonl`; pending tasks about sentinel runbook and Dev Logic templates remain unresolved for future sessions.
+- Enumerated `Dev_Logic/` resources; noted numerous subsystem modules (e.g., `tasks`, `error_console.py`, `background`, `repo_reference_helper.py`) slated for inlining.
+
+## Key Artifacts / References
+- `ACAGi.py`: primary orchestrator to be expanded.
+- `Dev_Logic/tasks/`, `Dev_Logic/error_console.py`, `Dev_Logic/background/`, `Dev_Logic/repo_reference_helper.py`: source implementations for inlining.
+- Testing utilities under `tools/`, notably `tools/manage_tests.py`.
+
+## Suggested Next Coding Steps
+1. Inspect current `ACAGi.py` to understand import points and integration touchpoints with external modules.
+2. Open each referenced module (`tasks`, `error_console`, `background`, `repo_reference_helper`, etc.) to document required classes/functions.
+3. Draft sections within `ACAGi.py` with descriptive headers/docstrings, replicating functionality inline and adapting references.
+4. Remove redundant imports and ensure namespace consistency.
+5. Run the mandated test suite (`python tools/manage_tests.py` or equivalent) and capture results.
+6. Update documentation artifacts (`CHANGELOG.md`, potentially README) to reflect monolithic refactor.
+
+## Open Questions / Risks
+- Need to confirm whether other modules depend on the same helpers; ensure no duplicated definitions cause divergence.
+- Validate that removing package imports does not break dynamic loading logic elsewhere in `ACAGi.py`.
+
+## Pending Inbox Items Impact
+- No direct progress on sentinel runbook or Dev Logic template; remain queued.
+
+## Work Notes
+- Inlined the task data models, bus, diff capture, TaskPanel/TaskDrawer UI, error console, background engines, and repository helper directly into `ACAGi.py` with dedicated section headers and docstrings for each subsystem.
+- Removed redundant imports from the former Dev_Logic modules and retained optional dependency guards for multimedia, OpenGL, and repository indexing.
+- Updated `CHANGELOG.md` and `memory/codex_memory.json` to document the architectural shift toward the monolithic file.
+
+## Tests & Validation
+- `python -m py_compile $(git ls-files '*.py')`
+- `QT_QPA_PLATFORM=offscreen pytest`
+- `python Dev_Logic/tools/manage_tests.py`
+- `python tools/logic_inbox.py validate memory/logic_inbox.jsonl`
+- `flake8` *(missing; command unavailable in container)*
+

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -16,6 +16,11 @@
       "title": "Runtime Optional Dependency Checks",
       "summary": "Handle optional libraries by importing them normally and relying on runtime capability helpers to emit user-facing warnings when dependencies are missing.",
       "applies_to": "python-optional-deps"
+    },
+    {
+      "title": "ACAGi Monolithic Ownership",
+      "summary": "Core task management, background rendering, error console, and repository helper logic now live directly in ACAGi.py; future changes should edit the single file sections instead of Dev_Logic modules.",
+      "applies_to": "acagi-architecture"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- inline task data models, event bus, diff capture, and TaskPanel/TaskDrawer UI from Dev_Logic into ACAGi.py with clear section headers
- embed the error console, background rendering engines, and repository reference helper directly in ACAGi.py while preserving optional dependency guards
- document the architectural shift in CHANGELOG.md, update codex memory lessons, and log session context/results

## Testing
- python -m py_compile ACAGi.py
- python -m py_compile $(git ls-files '*.py')
- QT_QPA_PLATFORM=offscreen pytest
- python Dev_Logic/tools/manage_tests.py
- python tools/logic_inbox.py validate memory/logic_inbox.jsonl
- flake8 *(missing in container environment)*

## Risk
- Medium: large-scale inlining touches many subsystems; rely on tests and optional dependency guards to mitigate regressions.

## Next Steps
- Monitor for runtime regressions when the desktop loads backgrounds or task UI, and consider pruning obsolete Dev_Logic modules in a follow-up.

------
https://chatgpt.com/codex/tasks/task_e_68dda905df188328b2145f1cf8a8173c