### PR TITLE
feat: add runtime settings loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# [0.1.5] - 2025-10-04
+### Added
+- Added a structured runtime settings loader (`acagi.ini`) that materializes defaults, documents config sections, and persists boolean/limit flags for offline, sandbox, and remote integrations.
+
+### Changed
+- Routed runtime feature flags into the event bus metadata, remote throttling, safety sentinel, and UI status bar so operators immediately see offline/sandbox context and configured rate limits.
+
 ## [0.1.4] - 2025-10-03
 ### Added
 - Introduced a Boot & Environment bootstrap in `ACAGi.py` that centralizes DPI policy, workspace/transit resolution, shared logging (`vd_system.log`), and the BrainShell crash dialog.

--- a/logs/session_2025-10-04.md
+++ b/logs/session_2025-10-04.md
@@ -1,0 +1,17 @@
+# Session Log — 2025-10-04
+
+## Objective
+- Implement runtime settings loader for ACAGi, integrate feature flags into event bus, sentinel, and UI, and document schema.
+
+## Context Highlights
+- Reviewed AGENT.md, memory, and logic inbox for governance and pending directives.
+- Current branch `work`; no remote `origin/main` available for diff baseline.
+
+## Key File Touchpoints
+- `ACAGi.py`: Added `SettingsLoader`, runtime feature propagation, sentinel wiring, and status bar updates.
+- `CHANGELOG.md`: Recorded 0.1.5 release notes summarizing loader and flag propagation.
+
+## Suggested Next Coding Steps
+- Extend settings dialog to expose new loader-backed toggles (offline, sandbox level, remote URLs).
+- Add automated tests covering `SettingsLoader` parsing and sentinel/event bus integration.
+- Evaluate workspace override workflow to refresh runtime settings path dynamically.

--- a/memory/logic_inbox.jsonl
+++ b/memory/logic_inbox.jsonl
@@ -1,2 +1,5 @@
 {"id": "2025-10-01-001", "title": "Draft Sentinel troubleshooting runbook", "status": "pending", "notes": "Expand Agent manual with failure recovery steps for codex-pr-sentinel."}
 {"id": "2025-10-01-002", "title": "Define Dev Logic proposal template", "status": "pending", "notes": "Create reusable markdown template in Dev_Logic for future design proposals."}
+{"id": "2025-10-04-001", "title": "Expose runtime flags in settings dialog", "status": "pending", "notes": "Hook offline, sandbox, and remote URLs into the preferences UI backed by the new SettingsLoader."}
+{"id": "2025-10-04-002", "title": "Test SettingsLoader parsing", "status": "pending", "notes": "Add unit coverage for INI defaults, override parsing, and error handling."}
+{"id": "2025-10-04-003", "title": "Handle workspace config rebinding", "status": "pending", "notes": "Reload runtime settings when the workspace override adjusts BootEnvironment paths."}


### PR DESCRIPTION
## Summary
- add a runtime SettingsLoader that documents the ini schema, persists defaults, and surfaces RuntimeSettings values globally
- feed loaded flags into the event bus metadata/remote throttling, the safety sentinel guard, and the main window status bar
- log the work in CHANGELOG.md, capture the session notes, and queue follow-up tasks in the logic inbox

## Testing
- python -m compileall ACAGi.py

## Risk
- Moderate: touches application bootstrap, event bus dispatch, and safety wiring; regressions could suppress events or safety prompts if misconfigured.

## Next Steps
- Extend the user preferences UI to manipulate the new settings loader and refresh runtime values without restart.


------
https://chatgpt.com/codex/tasks/task_e_68ddb262de0c832881275a38527f0308