### PR TITLE
refactor: inline dev logic imports into acagi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.6] - 2025-10-05
+### Changed
+- Consolidated safety guardrails, prompt loader, image pipeline, and repository indexing code directly into `ACAGi.py`, replacing sibling module imports with scoped sections referencing the Dev_Logic assets.
+- Embedded the token budget helpers into the monolithic module so runtime budget calculations no longer depend on external imports.
+
 # [0.1.5] - 2025-10-04
 ### Added
 - Added a structured runtime settings loader (`acagi.ini`) that materializes defaults, documents config sections, and persists boolean/limit flags for offline, sandbox, and remote integrations.

--- a/logs/session_2025-10-02.md
+++ b/logs/session_2025-10-02.md
@@ -17,3 +17,21 @@
 - Internal prompt: "Ensure ACAGi.py consistently presents itself as the single-entry module by updating documentation and status strings, then confirm syntax integrity via compileall."
 - Verify other documentation (e.g., Dev_Logic references) for lingering Codex Terminal branding during subsequent passes.
 - Progress pending logic inbox items on sentinel troubleshooting and Dev Logic templates when schedule allows.
+
+---
+
+## Session Update — 2025-10-02 (Import Consolidation)
+
+### Objective
+- Audit ACAGi.py sibling-module imports, inline the needed functionality into clearly labeled sections, and remove the now-redundant imports while preserving existing behavior.
+
+### Context
+- Reviewed AGENT.md, codex memory, and logic inbox items to align with verbose documentation, session logging, and single-file ownership standards.
+- Confirmed remote branches are unavailable after `git fetch --all --prune`, so the workspace is already aligned with local `work` without an `origin/main` to rebase onto.
+- Noted requirement to run `python -m compileall ACAGi.py` post-refactor per task brief.
+
+### Suggested Next Coding Steps
+- Internal prompt: "Trace each intra-repo import in ACAGi.py, transplant the necessary classes/functions into dedicated sections with provenance headers, remove the stale import statements, and re-run compileall to verify syntax."
+- Inventory the imported names from tasks, background, and repository helper modules to plan consolidation order.
+- Document any behavioral nuances from the inlined code via inline comments during migration.
+- Update memory and changelog if consolidation introduces new standards worth preserving.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -26,6 +26,11 @@
       "title": "Boot Environment Initialization",
       "summary": "ACAGi.py now centralizes DPI policy, workspace/transit resolution, shared logging, and BrainShell crash handling within a BootEnvironment manager; extend that section when adjusting startup flows.",
       "applies_to": "acagi-boot"
+    },
+    {
+      "title": "Dev Logic Path Constant",
+      "summary": "Use the DEV_LOGIC_ROOT constant within ACAGi.py when referencing prompts, datasets, or other assets migrated from Dev_Logic modules so paths remain stable after inlining.",
+      "applies_to": "acagi-architecture"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- Inline the token budget utilities, safety manager, prompt loader, vision pipeline, and repository index implementations into `ACAGi.py`, anchored by a shared `DEV_LOGIC_ROOT` constant.
- Remove the previous sibling-module imports and update runtime code to call the newly inlined helpers directly.
- Document the consolidation in the changelog and add a stable memory note covering the Dev Logic path constant.

## Testing
- python -m compileall ACAGi.py


------
https://chatgpt.com/codex/tasks/task_e_68ddc10dd4a48328bb6b3053c7f4c4cf