### PR TITLE
feat: add memory services and dataset persistence sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.8] - 2025-10-02
+### Added
+- Embedded a `MemoryServices` stack that loads durable lessons, instruction inbox items, and session JSONL tails during boot and exposes CRUD helpers for each store.
+- Introduced `DatasetNodePersistence` to split dataset entries into Git-friendly JSONL cores with vector/thumbnail sidecars and enforced metadata anchors.
+
+### Changed
+- Updated the dataset manager to rely on the new persistence helpers, automatically generating thumbnails and storing embeddings in sidecars while keeping JSONL entries lightweight.
+
 ## [0.1.7] - 2025-10-05
 ### Added
 - Introduced a topic-aware event dispatcher with bounded subscriber queues so observation, note, task, and system streams share a consistent pub/sub surface.

--- a/logs/session_2025-10-02.md
+++ b/logs/session_2025-10-02.md
@@ -58,3 +58,25 @@
 - Implemented an `EventDispatcher` with registered observation, note, task, and system topics plus bounded subscriber queues and remote throttling.
 - Connected dispatcher logs to the shared `VirtualDesktop` logger and verified publish/subscription activity produces structured telemetry entries.
 - Documented the change in `CHANGELOG.md`, updated codex memory with the dispatcher guidance, and ran `python -m compileall ACAGi.py` to confirm syntax integrity.
+
+## Session Update — 2025-10-02 (Memory + Dataset Persistence)
+
+### Objective
+- Stand up reusable memory services that hydrate durable lessons, the instruction inbox, and recent session tails on startup while exposing CRUD APIs for future automation.
+- Rework dataset persistence so each entry uses a Git-safe JSONL core with optional local sidecars for embeddings and thumbnails anchored by metadata files.
+
+### Context
+- Reviewed `AGENT.md`, `memory/codex_memory.json`, and `memory/logic_inbox.jsonl` to align with verbose documentation, governance requirements, and pending directives.
+- Confirmed the local `work` branch lacks a configured `origin/main`, so the mandatory rebase step is inapplicable after `git status`/`git log` snapshots.
+- Noted existing dataset manager embedded embeddings directly in JSONL entries and lacked sidecar metadata, making Git diffs noisy and losing anchor data.
+
+### Actions
+- Added `MemoryServices`, `DurableMemoryStore`, `InstructionInboxStore`, and `SessionTailStore` classes that load persistent lessons, instructions, and session JSONL tails during boot and provide CRUD helpers.
+- Wired memory services into the boot sequence, ensured singleton initialization, and added module-level convenience wrappers for session notes.
+- Implemented `DatasetNodePersistence` to manage JSONL cores plus vector/metadata/thumbnail sidecars and refactored `DatasetManager` to use anchors, metadata files, and optional thumbnail generation.
+- Updated `CHANGELOG.md` with the new memory/dataset capabilities and planned to run `python -m compileall ACAGi.py` for syntax verification.
+
+### Suggested Next Coding Steps
+- Extend UI surfaces to surface lesson/inbox/session data via the new memory services and add coverage for CRUD flows.
+- Backfill migration helpers that retrofit existing dataset.jsonl entries by emitting sidecar metadata and vector files where missing.
+- Consider caching embeddings to avoid repeated vector reads during frequent semantic searches.


### PR DESCRIPTION
## Summary
- embed durable lesson, instruction inbox, and session tail services that hydrate on boot and expose CRUD APIs
- persist dataset entries via JSONL cores plus vector/thumbnail sidecars with enforced metadata anchors
- wire the new services into the boot sequence and document the additions in the changelog

## Testing
- python -m compileall ACAGi.py

------
https://chatgpt.com/codex/tasks/task_e_68ddd6872d708328a0b7e66e58d8773d