### PR TITLE
Add Hippocampus dataset ingestion dock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.9] - 2025-10-02
+### Added
+- Added a Hippocampus-backed dataset manager dock that lets operators ingest
+  tagged files or directories from the UI while kicking off OCR, embedding, and
+  summarisation workflows.
+
+### Changed
+- Registered ingestion outputs with a persistent brain map registry so new
+  nodes and edges surface in the 3D visualisation after Hippocampus processes
+  them.
+
 ## [0.1.8] - 2025-10-02
 ### Added
 - Embedded a `MemoryServices` stack that loads durable lessons, instruction inbox items, and session JSONL tails during boot and exposes CRUD helpers for each store.

--- a/logs/session_2025-10-02.md
+++ b/logs/session_2025-10-02.md
@@ -80,3 +80,27 @@
 - Extend UI surfaces to surface lesson/inbox/session data via the new memory services and add coverage for CRUD flows.
 - Backfill migration helpers that retrofit existing dataset.jsonl entries by emitting sidecar metadata and vector files where missing.
 - Consider caching embeddings to avoid repeated vector reads during frequent semantic searches.
+
+## Session Update — 2025-10-02 (Dataset Manager Widget)
+
+### Objective
+- Introduce a dataset manager widget within ACAGi.py that lets users add files or directories and tag them into node datasets leveraging the Hippocampus APIs.
+- Trigger semantic ingestion (OCR, embeddings, summaries) for newly added assets and register resulting nodes/edges for the 3D brain map.
+- Validate syntax via `python -m compileall ACAGi.py` and document manual validation guidance.
+
+### Context
+- Re-read `AGENT.md`, `memory/codex_memory.json`, and `memory/logic_inbox.jsonl` to align with verbose documentation, logging, and workflow expectations.
+- Confirmed `git status -sb`, `git log -n 10 --oneline`, and `git fetch --all --prune` report no remote `origin/main`, so rebase is inapplicable for the current `work` branch.
+- Reviewed Dev_Logic notes to ensure new UI widgets align with centralized ACAGi.py ownership and dataset persistence patterns introduced previously.
+
+### Suggested Next Coding Steps
+- Internal prompt: "Design a dataset manager UI widget inside ACAGi.py that uses Hippocampus APIs to ingest tagged files/directories, kick off OCR/embedding/summary pipelines, and register nodes/edges in the brain map; capture manual test steps and verify syntax with compileall."
+- Sketch widget responsibilities: selection dialog, dataset tagging, ingestion status display, and integration with DatasetNodePersistence/Hippocampus clients.
+- Ensure ingestion pipeline hooks into existing semantic processors (OCR, embeddings, summaries) and brain map graph registration utilities.
+- Plan documentation updates (CHANGELOG entry, manual test steps in session log) alongside required compileall validation.
+
+### Manual Validation Steps
+- Launch ACAGi via `python ACAGi.py`, open **View → Dataset Manager** to reveal the new dock.
+- Use **Add Files…** to select a local text file; confirm the log shows an ingestion start message followed by a node summary.
+- Repeat with **Add Directory…** against a folder containing images to verify OCR/vision notes appear in the log and child edges are listed.
+- Inspect `sessions/<id>/hippocampus/brain_map.json` to confirm nodes and edges populate after ingestion.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -36,6 +36,11 @@
       "title": "Event Dispatcher Telemetry",
       "summary": "Route new pub/sub topics through the unified EventDispatcher so queue backpressure, logging, and remote fan-out remain consistent across observation, note, and task streams.",
       "applies_to": "acagi-events"
+    },
+    {
+      "title": "Hippocampus Dataset Dock",
+      "summary": "Use the DatasetManagerDock to ingest tagged files or directories so Hippocampus can run OCR/embeddings, persist dataset nodes, and update the brain map registry.",
+      "applies_to": "dataset-ingestion"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- add a Hippocampus client, brain map registry, and dataset ingest worker to persist OCR, embeddings, and summaries into datasets
- expose a Dataset Manager dock widget so operators can tag files or directories, run semantic ingestion, and register brain map nodes and edges
- document the new workflow in the changelog, codex memory, and session log

## Testing
- `python -m compileall ACAGi.py`

## Risk
- Medium: introduces new persistence flows and UI wiring that should be exercised manually with representative files.

## Next Steps
- Add automated coverage for Hippocampus ingest edge-cases and verify the brain map visualiser consumes the stored graph data.


------
https://chatgpt.com/codex/tasks/task_e_68de228f9824832885f14964c57dd6ae