### PR TITLE
feat: add sentinel monitors and policy enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.10] - 2025-10-04
+### Added
+- Introduced a sentinel monitor hub that subscribes to task/status topics, detects loops/regressions/stalls, and publishes immune responses with rationale on the `system.immune` stream.
+- Added a versioned `policies.json` template and settings loader support that materializes coder/test allowlists, denylists, sandbox requirements, and approval rules for SafetyManager.
+
+### Changed
+- Extended SafetyManager and command helpers to enforce operation policies, surface sandbox mismatches, and expose manual immune response triggering utilities.
+
 ## [0.1.9] - 2025-10-02
 ### Added
 - Added a Hippocampus-backed dataset manager dock that lets operators ingest

--- a/logs/session_2025-10-04.md
+++ b/logs/session_2025-10-04.md
@@ -15,3 +15,39 @@
 - Extend settings dialog to expose new loader-backed toggles (offline, sandbox level, remote URLs).
 - Add automated tests covering `SettingsLoader` parsing and sentinel/event bus integration.
 - Evaluate workspace override workflow to refresh runtime settings path dynamically.
+
+## Session – Sentinel policy wiring
+
+### Objective
+- Implement event-bus Sentinel monitors that surface loop/regression/stall immune responses and wire policies.json enforcement into command safety checks.
+
+### Context Highlights
+- `ACAGi.py` SafetyManager currently only matches regex-based risky commands; it must understand operation policies for coder/test flows.
+- Event dispatcher publishes task/status metrics but lacks Sentinel observers to translate anomalies into actionable responses.
+- Runtime settings loader persists ini values but does not yet broker JSON policy bundles.
+
+### Key File Touchpoints
+- `ACAGi.py` — expand SafetyManager, SettingsLoader, and event dispatcher sections.
+- `CHANGELOG.md` — capture sentinel monitor + policy enforcement update.
+- `policies.json` — seed versioned policy defaults for operations.
+
+### Suggested Next Coding Steps
+1. Define Sentinel monitor hub subscribing to task/status topics, detecting loops/regressions/stalls, and publishing immune responses with rationale.
+2. Extend SettingsLoader to source policies.json, produce structured policy objects, and push them into SafetyManager.
+3. Update SafetyManager/run_checked to enforce allow/deny/approval/sandbox requirements for coder/test operations.
+4. Document changes in CHANGELOG and ensure policy defaults exist on disk.
+5. Run `python -m compileall ACAGi.py` and log manual Sentinel trigger guidance.
+
+### Progress Notes
+- Added SentinelMonitorHub wiring to event dispatcher with cooldown/quarantine/rollback responses logged to `system.immune`.
+- Extended SafetyManager and SettingsLoader to parse `policies.json` and gate coder/test operations via allow/deny/approval checks.
+- Seeded repository `policies.json` template and documented the change in `CHANGELOG.md`.
+
+### Manual Sentinel Trigger Plan
+- Use `trigger_manual_immune_response(task_id, ImmuneResponse.<type>, reason, notes)` when an operator needs to escalate outside automated heuristics.
+- Manual triggers bypass backoff but still publish to `system.immune` with sandbox/policy metadata for auditing.
+- Pair manual triggers with session log annotations referencing the rationale and targeted recovery step.
+
+### Verification Checklist
+- Run `python -m compileall ACAGi.py` to ensure syntax integrity.
+- Exercise a sample coder command via `run_coder_command(["pytest", "-q"], operation context only)` inside a sandbox to observe allowlist approvals.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -41,6 +41,16 @@
       "title": "Hippocampus Dataset Dock",
       "summary": "Use the DatasetManagerDock to ingest tagged files or directories so Hippocampus can run OCR/embeddings, persist dataset nodes, and update the brain map registry.",
       "applies_to": "dataset-ingestion"
+    },
+    {
+      "title": "Sentinel Event Monitoring",
+      "summary": "SentinelMonitorHub listens to task.status/task.diff/task.updated topics, detects loops, regressions, and stalls, and publishes immune responses on system.immune.",
+      "applies_to": "safety-monitoring"
+    },
+    {
+      "title": "Operation Policy Enforcement",
+      "summary": "SafetyManager consumes policies.json to enforce coder/test allowlists, denylists, approval prompts, and sandbox requirements via run_checked helpers.",
+      "applies_to": "operation-safety"
     }
   ],
   "procedures": [

--- a/policies.json
+++ b/policies.json
@@ -1,0 +1,75 @@
+{
+  "version": "0.1.0",
+  "operations": {
+    "coder": {
+      "allow": [
+        "python",
+        "pip",
+        "pip3",
+        "pytest",
+        "ruff",
+        "black",
+        "mypy",
+        "npm",
+        "yarn",
+        "pnpm",
+        "node",
+        "cargo",
+        "go",
+        "mvn",
+        "gradle",
+        "make",
+        "git"
+      ],
+      "deny": [
+        "rm",
+        "sudo",
+        "chmod",
+        "chown",
+        "mkfs"
+      ],
+      "approval": [
+        "git"
+      ],
+      "sandbox_modes": [
+        "isolated",
+        "restricted"
+      ],
+      "notes": "Coder operations must run in restricted sandboxes and request approval before mutating repositories."
+    },
+    "test": {
+      "allow": [
+        "python",
+        "pytest",
+        "tox",
+        "npm",
+        "yarn",
+        "pnpm",
+        "bun",
+        "go",
+        "cargo",
+        "mvn",
+        "gradle",
+        "node",
+        "make"
+      ],
+      "deny": [
+        "rm",
+        "sudo",
+        "mkfs"
+      ],
+      "approval": [],
+      "sandbox_modes": [
+        "isolated",
+        "restricted",
+        "trusted"
+      ],
+      "notes": "Test operations focus on non-destructive tooling; destructive commands remain blocked."
+    }
+  },
+  "metadata": {
+    "generated": "repository default",
+    "updated": "2025-10-04",
+    "description": "Policies used by the safety manager to gate coder and tester operations."
+  }
+}


### PR DESCRIPTION
## Summary
- add a sentinel monitor hub that watches task event topics, detects loops/regressions/stalls, and emits immune responses with rationale on `system.immune`
- extend the settings loader and safety manager to load policies.json, enforce coder/test allowlists and denylists, and expose manual immune-response triggers
- version a default policies.json template and add keyword-only wrappers for coder/test command execution

## Testing
- python -m compileall ACAGi.py

------
https://chatgpt.com/codex/tasks/task_e_68de33379b0c832883181514fdfc3263