### PR TITLE
feat: add log observatory dock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## [0.1.13] - 2025-10-05
+### Added
+- Introduced a Log Observatory dock that tails the shared system log, scans
+  process/session streams, and surfaces filter/search controls while live
+  streaming Thalamus bus events.
+
+### Changed
+- Tabified the Log Observatory with the error console and exposed a view menu
+  toggle so operators can quickly switch between diagnostics surfaces.
+
 ## [0.1.12] - 2025-10-05
 ### Added
 - Introduced a Virtual Desktop dock that lazily initializes consoles, Dev Space

--- a/logs/session_2025-10-05.md
+++ b/logs/session_2025-10-05.md
@@ -40,3 +40,37 @@
 - [x] Run OCR workflow on sample image path to observe status messaging,
   markdown/text output, and history list population.
 - [x] Execute `python -m compileall ACAGi.py` to ensure syntax integrity.
+
+## Session 2025-10-05T00:00Z+ Log Dock Integration
+### Objective
+- Implement a log observability dock within `ACAGi.py` that tails shared system and per-process/session streams with filtering controls and live Thalamus bus updates.
+- Ensure syntax validation via `python -m compileall ACAGi.py` and capture planned filter test cases.
+
+### Context Snapshot
+- `git status` shows a clean working tree on branch `work`.
+- Remote `origin/main` is unavailable in this environment; `git diff origin/main...HEAD` cannot resolve.
+- Pending logic inbox items remain outstanding (`Draft Sentinel troubleshooting runbook`, `Define Dev Logic proposal template`, runtime settings tasks).
+
+### File Notes
+- `ACAGi.py`: will host new log dock class, UI wiring, and Thalamus bus subscriptions for append-only viewer updates.
+- `logs/session_2025-10-05.md`: logging this session's objective, notes, and suggested steps.
+
+### Suggested Next Coding Steps
+1. Survey existing dock/widget patterns in `ACAGi.py` to mirror layout conventions and logging infrastructure.
+2. Design a `LogObservabilityDock` (name TBD) encapsulating text viewer, filter/search inputs, and per-stream toggle controls.
+3. Integrate the dock into the main window/tab fabric, ensuring event bus handlers format entries with accessible contrast.
+4. Draft filter-focused test cases for manual verification and record them in this session log.
+5. Run `python -m compileall ACAGi.py` to verify syntax.
+
+
+### Filter/Search Test Cases
+- Apply a single-term filter (e.g., `error`) and confirm only matching system log
+  lines remain while new Thalamus events respecting the filter append live.
+- Chain multi-term filters (`bridge ready`) to verify AND semantics across both
+  shared system log tails and incoming event summaries.
+- Use the search box to step through process log entries containing `pid=` while
+  switching between different process files.
+- Filter a session tail by user role (`user`) and ensure refreshed conversation
+  entries still respect the filter after new `task.conversation` events arrive.
+- Clear filters and confirm scroll positions snap to the end of each view when
+  new filesystem log lines stream in via the timers.


### PR DESCRIPTION
## Summary
- add a Log Observatory dock that tails system, process, and session streams with filter/search controls and Thalamus bus streaming
- expose the dock in the main window, tabifying it with the error console and wiring a view menu toggle

## Testing
- python -m compileall ACAGi.py

## Risk
- Low: UI-only changes guarded behind an optional dock with read-only file access

## Next Steps
- Expand automated coverage for log filtering semantics and process/session discovery

------
https://chatgpt.com/codex/tasks/task_e_68de4766cf948328842a94b66083ff6c