### PR TITLE
Add brain map dock with Dev Space activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+## [0.1.14] - 2025-10-05
+### Added
+- Introduced a Brain Map dock that lazily initialises a graphics scene to render
+  Hippocampus nodes and typed edges with energy/salience overlays and Dev Space
+  activation callbacks.
+- Added energy heatmap, queue depth, and error ray toggles so operators can
+  spotlight different operational metrics while reviewing the graph.
+
+### Changed
+- Linked the Brain Map dock with the Virtual Desktop focus helper to jump into
+  Dev Space diagnostics whenever a node is selected.
+- Ensured theme/settings reloads refresh the Brain Map registry reference and
+  exposed a View menu toggle alongside other investigative docks.
+
 ## [0.1.13] - 2025-10-05
 ### Added
 - Introduced a Log Observatory dock that tails the shared system log, scans

--- a/logs/session_2025-10-02.md
+++ b/logs/session_2025-10-02.md
@@ -127,3 +127,26 @@
 - Launch ACAGi and start the Codex bridge; confirm the LED logs a "Bridge warming up" notice, shows yellow while the console boots, and flips to green once the ready banner surfaces.
 - Trigger a Codex approval prompt (e.g., request a privileged file write) and verify the inline widget appears, buttons send tokens, and the LED cycles yellow→green after the approval completes.
 - Tap a user or assistant transcript bubble and ensure a `[Memory] Saved …` system notice appears with an anchor snippet while Hippocampus receives the full text.
+## Session Update — 2025-10-02 (Brain Map Dock)
+
+### Objective
+- Introduce a dockable brain map widget that lazily renders Hippocampus nodes and typed edges with energy/salience overlays.
+- Ensure interacting with brain map nodes activates the Virtual Desktop Dev Space for deeper analysis.
+- Surface operator toggles for energy heatmap, queue depth, and error ray overlays while documenting manual rendering checks.
+
+### Context
+- Reviewed `AGENT.md`, `memory/codex_memory.json`, and `memory/logic_inbox.jsonl` alongside Dev_Logic notes to respect verbose documentation and single-file ownership mandates.
+- `git status -sb` confirms the `work` branch is clean; a remote `origin/main` is unavailable so `git diff origin/main...HEAD` fails (logged earlier).
+- ACAGi already persists `hippocampus/brain_map.json` but lacks an interactive UI; Virtual Desktop Dev Space exposes diagnostics we can reuse when nodes are selected.
+
+### Suggested Next Coding Steps (Self-Prompt)
+1. Extend `VirtualDesktopDock` with a helper that focuses the Dev Space tab and logs node activation metadata.
+2. Implement a `BrainMapDock` class that defers heavy graphics initialization until visible, polls the `BrainMapRegistry`, and renders nodes/edges with optional metric overlays.
+3. Wire the new dock into `MainWindow`, add View menu toggles, and ensure the dock starts/stops a refresh timer based on visibility.
+4. Capture manual rendering checks (visibility toggle, overlay switches, node→Dev Space hand-off) in this session log and run `python -m compileall ACAGi.py` for syntax validation.
+
+### Manual Rendering Checks
+- [ ] Toggle **View → Brain Map** to confirm the dock lazily instantiates the scene and reports node/edge counts.
+- [ ] Enable **Energy heatmap**, **Queue depth**, and **Error rays** toggles independently to verify overlays update without recreating the view.
+- [ ] Click a node to ensure the Virtual Desktop dock becomes visible with the Dev Space tab focused and a log entry appended.
+- [ ] Switch styles or settings and confirm the brain map registry reloads without raising exceptions.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -61,6 +61,11 @@
       "title": "Virtual Desktop Dock Integration",
       "summary": "Virtual Desktop features now live in a dockable widget that lazily instantiates consoles, Dev Space tabs, and OCR overlays while consuming event bus updates for tasks, logs, and datasets.",
       "applies_to": "ui-virtual-desktop"
+    },
+    {
+      "title": "Brain Map Dock",
+      "summary": "ACAGi includes a BrainMapDock that lazily renders Hippocampus nodes and typed edges with energy/salience overlays and Dev Space focus callbacks when nodes are selected.",
+      "applies_to": "ui-brain-map"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- add a dockable brain map widget that lazily renders Hippocampus nodes/edges and exposes metric overlays
- ensure node clicks drive Virtual Desktop Dev Space focus and surface new view/menu wiring plus documentation updates
- record workflow context in the session log and structured memory for the new brain map experience

## Testing
- `python -m compileall ACAGi.py`

## Risk
- Low: UI-only feature guarded by lazy initialization and existing event subscriptions

## Next Steps
- Consider wiring real-time event updates into the brain map dock to eliminate polling refreshes

------
https://chatgpt.com/codex/tasks/task_e_68de4c564a6883288ed666e20702fb25