### PR TITLE
feat: add command palette and macro playbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## [0.1.15] - 2025-10-05
+### Added
+- Added a Ctrl+K command palette overlay that lists policy-reviewed commands and persisted playbook macros while dispatching selections through the event bus.
+- Introduced Dev Space playbook management with JSONL-backed promotion flows and manual macro execution note tracking.
+
+### Changed
+- Extended safety policies with action-level enforcement for palette triggers and seeded macro defaults in the policy bundle.
+
 ## [0.1.14] - 2025-10-05
 ### Added
 - Introduced a Brain Map dock that lazily initialises a graphics scene to render

--- a/logs/session_2025-10-05.md
+++ b/logs/session_2025-10-05.md
@@ -74,3 +74,31 @@
   entries still respect the filter after new `task.conversation` events arrive.
 - Clear filters and confirm scroll positions snap to the end of each view when
   new filesystem log lines stream in via the timers.
+## Session Update — 2025-10-05 (Command Palette & Playbooks)
+
+### Objective
+- Provide a Ctrl+K command palette overlay that enumerates available commands and macros with inline policy hints.
+- Persist macro playbooks as ordered JSONL definitions and expose promotion flows within the Dev Space UI.
+- Capture manual macro execution notes for follow-up verification.
+
+### Context
+- Reviewed `AGENT.md`, structured memory, and the logic inbox to respect verbose documentation, testing, and governance policies.
+- `git status` shows the `work` branch clean; attempted `git diff origin/main...HEAD` fails because no remote is configured in this environment.
+- EventDispatcher already centralizes topic publishing and policy metadata injection, positioning it for command palette dispatch hooks.
+- Dev Space widgets expose task/macro surfaces but lack persistence flows for playbooks.
+
+### Suggested Next Coding Steps (Self-Prompt)
+1. Survey existing keyboard shortcut registrations in `MainWindow` to align the Ctrl+K binding and overlay lifecycle with other docks.
+2. Implement a `CommandPaletteDialog` that ingests registered commands/macros, filters live as the user types, and emits the selected entry through the event bus after consulting the SafetyManager.
+3. Design macro serialization helpers that load/save ordered JSONL steps, update Dev Space UI state, and surface a "Promote to Playbook" action that persists through the new helpers.
+4. Update documentation (`CHANGELOG.md`) and manual note sections, then validate syntax with `python -m compileall ACAGi.py` before committing.
+
+### Validation Plan
+- Trigger Ctrl+K to open the palette, search for a command, and confirm the highlighted entry executes via the event bus with logged policy decisions.
+- Save a macro playbook, reload ACAGi, and verify steps hydrate in original order.
+- Promote a Dev Space macro to a playbook and ensure the UI reflects persistence success with logging annotations.
+
+### Manual Macro Execution Notes (scheduled)
+- Palette command `focus_chat_input` (policy: macro) — confirm Ctrl+K → Enter moves focus to the chat composer and logs a `system.command` dispatch.
+- Palette command `toggle_virtual_desktop` (policy: macro) — verify dock visibility toggles, status bar messaging updates, and manual notes record the transition.
+- Playbook run (policy: macro) — after promoting a playbook, trigger it from the palette and confirm each step publishes with ordered metadata and a manual review note.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -66,6 +66,11 @@
       "title": "Brain Map Dock",
       "summary": "ACAGi includes a BrainMapDock that lazily renders Hippocampus nodes and typed edges with energy/salience overlays and Dev Space focus callbacks when nodes are selected.",
       "applies_to": "ui-brain-map"
+    },
+    {
+      "title": "Command Palette Dispatch Pattern",
+      "summary": "Palette-triggered commands and macros must register PaletteEntry descriptors, run safety_manager.ensure_action_allowed before publishing to the event bus, and log manual macro notes for follow-up review.",
+      "applies_to": "ui-command-palette"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- add macro playbook data structures, JSONL persistence helpers, and action-level policy enforcement for palette execution
- introduce a Ctrl+K command palette with registered commands, playbook entries, and event bus publishing
- extend the Dev Space with a Playbooks tab for promoting macros and tracking manual execution notes

## Testing
- python -m compileall ACAGi.py

------
https://chatgpt.com/codex/tasks/task_e_68de50ebedbc8328b2efaefc4da548a4