### PR TITLE
feat: add cerebellum rationalizer manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Changelog
+## [0.1.18] - 2025-10-07
+### Added
+- Introduced a Cerebellum scheduler and Rationalizer manager that spin up
+  short-lived workers for intent segmentation and reference resolution while
+  enforcing Gate quotas.
+- Published cortex rationalizer results on new `cortex.intent` and
+  `cortex.reference` event topics alongside telemetry on `system.metrics`.
+
+### Changed
+- Extended default settings with Cerebellum quota controls and wired the chat
+  workflow to queue Rationalizer jobs whenever a user message is recorded.
+
+### Validation
+- Ran `python -m compileall ACAGi.py` to confirm syntax integrity.
+
 ## [0.1.17] - 2025-10-07
 ### Added
 - Embedded local-first ASR and TTS adapters inside `ACAGi.py` with streaming

--- a/logs/session_2025-10-02.md
+++ b/logs/session_2025-10-02.md
@@ -150,3 +150,31 @@
 - [ ] Enable **Energy heatmap**, **Queue depth**, and **Error rays** toggles independently to verify overlays update without recreating the view.
 - [ ] Click a node to ensure the Virtual Desktop dock becomes visible with the Dev Space tab focused and a log entry appended.
 - [ ] Switch styles or settings and confirm the brain map registry reloads without raising exceptions.
+## Session Update — 2025-10-02 (Rationalizer Manager Integration)
+
+### Objective
+- Introduce a Rationalizer manager responsible for spinning up short-lived workers that perform intent segmentation and reference resolution within ACAGi.py.
+- Connect Rationalizer scheduling into the Cerebellum task scheduler so cognitive jobs are balanced with existing event workloads.
+- Enforce Gate-provided energy quotas/backpressure so concurrent Rationalizers respect system limits, then validate syntax with `python -m compileall ACAGi.py`.
+
+### Context
+- Reviewed `AGENT.md`, `memory/codex_memory.json`, and `memory/logic_inbox.jsonl` to stay aligned with verbose commentary, session logging, and pending directives.
+- Confirmed the repository tracks branch `work` with no remote `origin/main`, so rebase against upstream is not applicable; previous attempts to diff `origin/main...HEAD` fail for this reason.
+- Current ACAGi.py lacks a dedicated Rationalizer manager or Cerebellum scheduler hooks; Gate telemetry exists only as UI placeholders, so new coordination structures must be introduced carefully with extensive logging and documentation.
+
+### Suggested Next Coding Steps (Self-Prompt)
+1. Sketch data models for Rationalizer jobs (intent segmentation, reference resolution) and the worker lifecycle, including structured logging and timing metrics.
+2. Implement a Cerebellum scheduler core that can accept queued Rationalizer tasks, manage worker threads, and expose telemetry back to Gate controls.
+3. Build a RationalizerManager that requests work slots from Gate, spins up short-lived workers, publishes results through the event dispatcher, and releases quotas when work finishes or fails.
+4. Wire the manager into the boot sequence and status telemetry feeds, ensuring Gate quotas/backpressure are enforced and log outputs reflect concurrency decisions.
+5. Document behavior in `CHANGELOG.md`, update durable memory if new standards emerge, and validate syntax via `python -m compileall ACAGi.py`; outline concurrency test scenarios in this log for future execution.
+
+### Validation Plan
+- [ ] Run `python -m compileall ACAGi.py` to confirm syntax integrity.
+- [ ] Describe a set of manual/automated concurrency stress tests for Rationalizer backpressure in this session log and final summary.
+- [ ] Capture event/log telemetry expectations for Rationalizer scheduling decisions.
+
+### Concurrency Test Outline
+- [ ] Warm start ACAGi, send five rapid user utterances with varying reference suggestions, and confirm logs show Gate permits at most the configured Rationalizer slots while queue depth grows without exceeding limits.
+- [ ] Artificially lower the Cerebellum queue limit via settings reload to ensure submissions beyond the cap emit queue-full warnings and publish drop telemetry on `system.metrics`.
+- [ ] Temporarily set the Rationalizer limit to zero and verify user messages log Gate rejections without launching workers, then restore limits and confirm jobs resume.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -81,6 +81,11 @@
       "title": "Speech Orchestrator and Amygdala Salience",
       "summary": "Local ASR/TTS adapters now publish speech activity, partial/final transcripts, and TTS telemetry on dedicated event bus topics while the Amygdala component weights diarization metadata and emits system.salience scores.",
       "applies_to": "voice-interface"
+    },
+    {
+      "title": "Cerebellum Rationalizer Quotas",
+      "summary": "Rationalizer jobs are dispatched through the Cerebellum scheduler which enforces Gate quotas, publishes cortex.intent and cortex.reference events, and surfaces telemetry on system.metrics; future cognitive workflows should integrate with ensure_rationalizer_manager rather than spawning ad-hoc threads.",
+      "applies_to": "cortex-rationalizer"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- add a GateQuotaController, CerebellumScheduler, and RationalizerManager so rationalizer jobs respect Gate quotas and publish metrics on the event bus
- expose new cortex intent/reference topics, extend default settings with Cerebellum quotas, and wire ChatCard/MainWindow to queue rationalizer jobs for user messages
- document the architecture in CHANGELOG and memory entries while outlining concurrency validation steps in the session log

## Testing
- python -m compileall ACAGi.py

## Risk
- Medium: new scheduler threads and gating logic coordinate chat flows; monitor for deadlocks or dropped jobs under high load

## Next Steps
- Execute the outlined concurrency stress tests to confirm Gate limits and queue drops behave as expected

------
https://chatgpt.com/codex/tasks/task_e_68de6864670883288a664e90f4c08414