### PR TITLE
feat: orchestrate task bucket lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # Changelog
+## [0.1.19] - 2025-10-08
+### Added
+- Added task bucket lifecycle data classes and orchestration helpers that drive
+  capture→note→bucketize→assemble→apply→test→verify→promote transitions while
+  emitting stage telemetry on new event topics.
+- Exposed a bucket stage context/result API so handlers can enrich metadata,
+  touched files, and notes for downstream observers.
+
+### Changed
+- Introduced a serialization manager that leases Apply/Test/Verify stages when
+  buckets touch overlapping files, maintaining parallelism for upstream
+  assembly work while preventing conflicting writes.
+
+### Validation
+- Ran `python -m compileall ACAGi.py` to confirm syntax integrity.
+
 ## [0.1.18] - 2025-10-07
 ### Added
 - Introduced a Cerebellum scheduler and Rationalizer manager that spin up

--- a/logs/session_2025-10-08.md
+++ b/logs/session_2025-10-08.md
@@ -1,0 +1,29 @@
+# Session Log — 2025-10-08
+
+## Objective
+- Implement Task Bucket lifecycle orchestration in `ACAGi.py` so capture→note→bucketize→assemble→apply→test→verify→promote flows operate end-to-end with serialization on Apply/Test/Verify when buckets share file touch sets.
+- Persist data structures, logging, and configuration required to monitor bucket stages.
+- Record validation approach including `python -m compileall ACAGi.py` and enumerate manual/automated acceptance coverage for bucket flows.
+
+## Context Highlights
+- Reviewed `AGENT.md`, `memory/codex_memory.json`, `memory/logic_inbox.jsonl`, and prior session logs to maintain verbose documentation standards and acknowledge pending directives (Sentinel runbook, Dev Logic templates, runtime settings work still open).
+- Repository tracks branch `work` without a configured remote; synchronization with `origin/main` is not applicable.
+- Existing `ACAGi.py` includes task models and event infrastructure but lacks explicit bucket lifecycle orchestration with file-touch aware serialization across apply/test/verify stages.
+- No automated bucket acceptance tests currently exist; we will document manual flows and highlight any future test harness requirements.
+
+## Suggested Next Coding Steps (Self-Prompt)
+1. Design TaskBucket data classes capturing task metadata, touched files, stage timestamps, locks, and state transitions while integrating with the event dispatcher logging facilities.
+2. Implement lifecycle handlers that execute capture→note→bucketize→assemble→apply→test→verify→promote steps, ensuring upstream steps run asynchronously while apply/test/verify enforce serialization for buckets that overlap file touch sets via a coordination manager.
+3. Integrate new orchestration into existing task management infrastructure in `ACAGi.py`, updating docstrings and logging for visibility and resilience on failure cases.
+4. Update `CHANGELOG.md` with a new entry describing Task Bucket orchestration, and record the validation strategy in this session log and PR narrative.
+5. Run `python -m compileall ACAGi.py` to confirm syntax, capture outputs for reporting, and list unit/manual acceptance tests relevant to the bucket flow.
+
+## Validation Checklist
+- [ ] Exercise a dry-run of the bucket orchestration by simulating capture→promote transitions using mock tasks to ensure stage transitions and logging behave as expected (manual/diagnostic invocation).
+- [ ] Confirm serialization manager defers apply/test/verify when overlapping file sets are in-flight, using logging to verify queueing behavior.
+- [x] Run `python -m compileall ACAGi.py` to validate syntax after modifications.
+- [x] Document acceptance coverage (unit or manual) for Task Bucket flows in the final report and `CHANGELOG.md`.
+
+## Acceptance Tests
+- **Manual Dry-Run:** Invoke `TaskBucketLifecycleRunner` with stub handlers that record execution order, ensuring the capture→note→bucketize→assemble→apply→test→verify→promote loop publishes stage telemetry on `task.bucket.stage`.
+- **Manual Contention Check:** Execute two buckets with overlapping touched files and observe serialization logs to confirm Apply/Test/Verify stages acquire leases sequentially.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -86,6 +86,11 @@
       "title": "Cerebellum Rationalizer Quotas",
       "summary": "Rationalizer jobs are dispatched through the Cerebellum scheduler which enforces Gate quotas, publishes cortex.intent and cortex.reference events, and surfaces telemetry on system.metrics; future cognitive workflows should integrate with ensure_rationalizer_manager rather than spawning ad-hoc threads.",
       "applies_to": "cortex-rationalizer"
+    },
+    {
+      "title": "Task Bucket Serialization Discipline",
+      "summary": "Task buckets advance through capture→note→bucketize→assemble→apply→test→verify→promote with Apply/Test/Verify serialized via file-touch leases so concurrent buckets do not race on shared paths.",
+      "applies_to": "task-orchestration"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- add task bucket stage models, lifecycle runner, and serialization manager to drive the capture→note→bucketize→assemble→apply→test→verify→promote workflow with event telemetry
- extend the dispatcher topics and context/result helpers so bucket handlers can annotate touched files, metadata, and notes for downstream consumers
- document the new orchestration in the changelog and memory store for future sessions

## Testing
- python -m compileall ACAGi.py

## Risk
- medium: lifecycle orchestration under active development; ensure bucket handlers are updated to return touched file data before entering serialized stages

## Next Steps
- add automated regression tests that exercise serialization conflicts and end-to-end bucket promotion flows


------
https://chatgpt.com/codex/tasks/task_e_68de6e4f42a48328ad330455a72deb57