### PR TITLE
feat: add ScriptSpeak parser and automation wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+## [0.1.21] - 2025-10-09
+### Added
+- Introduced a ScriptSpeak parser that normalises verbs, arguments, and flags
+  into structured payloads and publishes them on a dedicated `script.command`
+  event stream with session log journaling.
+- Wired macro playbooks and ad-hoc macro events through the parser so queued
+  automation steps emit auditable ScriptSpeak instructions.
+- Extended the Rationalizer manager to forward ScriptSpeak guidance emitted in
+  job results onto the event bus with per-job metadata, enabling automated
+  follow-ups to appear in session transcripts.
+
+### Validation
+- Ran `python -m compileall ACAGi.py` to confirm syntax integrity.
+
 ## [0.1.20] - 2025-10-08
 ### Added
 - Implemented coder/test/verifier lifecycle handlers that capture anchored patches

--- a/logs/session_2025-10-09.md
+++ b/logs/session_2025-10-09.md
@@ -1,0 +1,37 @@
+# Session Log — 2025-10-09
+
+## Objective
+- Implement a ScriptSpeak command parser within `ACAGi.py` that translates verbs/arguments/flags into event bus actions.
+- Wire the parser into the Rationalizer and macro automation layers so automated flows can emit ScriptSpeak instructions.
+- Validate bytecode compilation (`python -m compileall ACAGi.py`) and plan manual parsing tests.
+
+## Context Recap
+- Current branch `work`; remote `origin/main` is unavailable in this checkout (fetch succeeds but `origin/main` ref missing), so rebasing is blocked and noted here.
+- `EventDispatcher` centralises pub/sub for `system.*`, `cortex.*`, etc.; macros (`MacroPlaybook`) serialize ScriptSpeak steps but currently lack a parser/dispatcher bridge.
+- RationalizerManager submits jobs to CerebellumScheduler and publishes `cortex.intent` / `cortex.reference` events without ScriptSpeak encoding.
+
+## File Notes
+- `ACAGi.py` (~8k lines) houses event bus, macros, rationalizers, UI wiring; additions must include docstrings and logging per Agent manual.
+
+## Suggested Next Coding Steps (Self-Prompt)
+1. Design a `ScriptSpeakParser` helper that tokenizes verbs, `key=value` arguments, and `--flags`; produce structured commands and map to event dispatcher calls.
+2. Embed parser access points where macros/rationalizers emit actions—ensure session logs capture emitted ScriptSpeak strings.
+3. Update documentation or changelog entries reflecting ScriptSpeak support and record manual test checklist.
+4. Run `python -m compileall ACAGi.py`; document queued manual tests.
+
+## Open Questions
+- Need to confirm event topic naming conventions to map verbs → topics/actions before finalizing parser table.
+
+## Work Log
+- Drafted the ScriptSpeak parsing helper with verb/category lookup, shlex-based tokenisation, and session log journaling hooks.
+- Wired macro playbook ingestion to rebuild MacroStep models and emit parsed ScriptSpeak commands on the `script.command` topic.
+- Extended the Rationalizer manager to forward any ScriptSpeak payloads returned by workers into the shared dispatcher with job metadata.
+- Updated durable memory with a new lesson describing the ScriptSpeak dispatch surface and recorded this implementation in the changelog.
+
+## Validation Plan
+- [x] `python -m compileall ACAGi.py`
+- [ ] Manual parsing spot-checks:
+  - Feed `CREATE_BUCKET title="Add parser" bucket=BKT-01 --dry-run` and confirm an event publishes with verb/arguments/flags recorded.
+  - Trigger a mock macro payload containing ScriptSpeak steps and ensure dispatch events append to the session log tail.
+  - Simulate a Rationalizer result with a `scriptspeak` array and verify each command is parsed without raising errors.
+

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -96,6 +96,11 @@
       "title": "Task Bucket Failure Rationalization Loop",
       "summary": "When a task bucket stage fails ACAGi queues a Rationalizer job with the failure context and updates the durable memory snapshot with the latest telemetry so follow-up runs start with concrete remediation clues.",
       "applies_to": "task-orchestration"
+    },
+    {
+      "title": "ScriptSpeak Command Dispatch",
+      "summary": "ScriptSpeak commands are parsed into structured events on the script.command topic, mirrored into session logs, and reused by macros and Rationalizer outputs for auditable automation.",
+      "applies_to": "scriptspeak"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- introduce a ScriptSpeak parser that tokenizes verbs/arguments/flags, publishes `script.command` events, and records session log entries
- wire macro playbook dispatch and ad-hoc macro payloads through the parser so ScriptSpeak instructions are emitted for review
- extend the Rationalizer manager to forward ScriptSpeak guidance from job results and document the changes in the changelog and memory store

## Testing
- python -m compileall ACAGi.py

------
https://chatgpt.com/codex/tasks/task_e_68de7decdc608328abdd7c91b193dc7b