### PR TITLE
feat(remote): detect tooling and sync remote toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 # Changelog
+## [0.1.22] - 2025-10-09
+### Added
+- Added local GitHub Desktop and GitHub CLI detection with status badges in the
+  status bar telemetry panel and Settings dialog, avoiding any outbound network
+  probes.
+- Introduced a `RemoteAccessController` that gates remote fan-out behind an
+  explicit toggle, syncs safety policy notices, and emits ScriptSpeak
+  `TOGGLE_REMOTE` events with rich metadata.
+
+### Changed
+- Extended the status bar summary with remote tooling availability indicators
+  alongside remote link posture.
+- Updated the Settings dialog to surface remote toggle state and detection
+  tooltips inside a dedicated "Remote Access" section.
+
+### Validation
+- Ran `python -m compileall ACAGi.py` to confirm syntax integrity.
+- Documented manual remote toggle verification in
+  `logs/session_2025-10-02.md`.
+
 ## [0.1.21] - 2025-10-09
 ### Added
 - Introduced a ScriptSpeak parser that normalises verbs, arguments, and flags

--- a/logs/session_2025-10-02.md
+++ b/logs/session_2025-10-02.md
@@ -201,3 +201,28 @@
 - [ ] Configure multiple validation commands (pass + fail) and ensure the test stage records stdout/stderr and marks bucket telemetry appropriately.
 - [ ] Force a test failure to verify the Rationalizer queue receives a failure summary and `codex_memory.json` updates the staged-learning entry.
 - [ ] Complete a successful apply→test→verify sequence and inspect telemetry updates on the status bar/task drawer when available.
+## Session Update — 2025-10-02 (Remote Capability Toggle & Detection)
+
+### Objective
+- Detect local installations of GitHub Desktop and the GitHub CLI without triggering any outbound requests.
+- Surface the detection results inside the Settings dialog and status bar telemetry cluster for operator visibility.
+- Introduce a centralized remote access toggle that synchronizes the event bus fan-out, safety policies, and ScriptSpeak emissions.
+- Validate syntax with `python -m compileall ACAGi.py` and document manual verification for the remote control toggle.
+
+### Context
+- Reviewed `AGENT.md`, `memory/codex_memory.json`, and `memory/logic_inbox.jsonl` to align with verbose documentation, memory hygiene, and outstanding directives.
+- Captured repository context via `git status -sb` and `git log -n 10 --oneline`; `git fetch --all --prune` succeeded but the follow-up `git rebase origin/main` failed because the remote branch is absent in this workspace.
+- Attempted `git diff origin/main...HEAD` as required; it failed with `fatal: ambiguous argument 'origin/main...HEAD'`, confirming no upstream reference is available (captured for auditing).
+- Confirmed no nested `AGENT.md` overrides exist, so top-level guidelines apply to all touched files.
+- Requirements call for gating all remote capabilities through an explicit toggle that also updates ScriptSpeak outputs, implying we must plumb state transitions through the dispatcher and policy layers.
+
+### Suggested Next Coding Steps
+- Self-prompt: "Design a `RemoteAccessController` that records detection results for GitHub Desktop and gh, exposes UI-friendly summaries, and mediates remote fan-out/policy/script events whenever the toggle changes; then thread the controller through the status bar and settings dialog while capturing manual verification steps."
+- Sketch detection helpers that scan common installation paths and `PATH` entries without shelling out to network tools.
+- Expand `StatusBarTelemetryPanel` and `SettingsDialog` with new widgets summarizing remote tooling availability and toggle state.
+- Ensure the remote toggle publishes a `TOGGLE_REMOTE` ScriptSpeak dispatch, refreshes safety policies, and logs manual verification guidance before running `python -m compileall ACAGi.py`.
+
+### Manual Remote Toggle Verification Plan
+1. Launch ACAGi locally, confirm the status bar shows GitHub Desktop and gh CLI detection badges.
+2. Click the remote toggle off; verify the status summary reflects "Remote paused," safety policy messages log the state change, and a ScriptSpeak `TOGGLE_REMOTE` entry appears in session logs.
+3. Re-enable the toggle; confirm remote fan-out re-activates without initiating network traffic and UI tooltips update accordingly.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "last_updated": "2025-10-08",
+  "last_updated": "2025-10-09",
   "stable_lessons": [
     {
       "title": "Verbose Implementation Standard",
@@ -101,6 +101,11 @@
       "title": "ScriptSpeak Command Dispatch",
       "summary": "ScriptSpeak commands are parsed into structured events on the script.command topic, mirrored into session logs, and reused by macros and Rationalizer outputs for auditable automation.",
       "applies_to": "scriptspeak"
+    },
+    {
+      "title": "Remote Access Controller Toggle",
+      "summary": "Remote fan-out must route through the RemoteAccessController so UI state, safety policies, and ScriptSpeak notifications stay synchronised whenever remote actions are enabled or paused.",
+      "applies_to": "remote-control"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- detect GitHub Desktop and GitHub CLI installations without network probes and surface the results in the status bar and Settings dialog
- introduce a RemoteAccessController that coordinates remote fan-out toggles with safety policy notifications and ScriptSpeak events
- expand the status bar and settings UI to expose remote tooling badges and richer remote state summaries

## Testing
- python -m compileall ACAGi.py

## Risk
- Medium: remote fan-out gating and UI wiring now flow through a centralized controller and should be exercised in the desktop shell.

## Next Steps
- Extend the Settings dialog with additional runtime flag editors once remaining logic inbox items advance.


------
https://chatgpt.com/codex/tasks/task_e_68dee76d4d008328af716e627b3c0b7b