### PR TITLE
feat: surface sentinel failures with recovery guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Changelog
+## [0.1.24] - 2025-10-10
+### Added
+- Emitted structured `system.sentinel` events for Codex bridge loss, sandbox
+  corruption repairs, and repeated task regressions with UI dialogs that meet
+  high-contrast requirements and surface recovery guidance.
+- Created `Dev_Logic/Implemented_logic/2025-10-10-sentinel-failure-injection.md`
+  documenting manual failure injection steps for each new sentinel pathway.
+
+### Changed
+- Extended the sentinel monitor with regression counters that escalate after
+  successive rollbacks and wired the terminal to subscribe to sentinel history
+  so startup alerts replay into the chat log.
+
+### Validation
+- Ran `python -m compileall ACAGi.py` to confirm syntax integrity.
+- Logged failure simulation procedures in
+  `Dev_Logic/Implemented_logic/2025-10-10-sentinel-failure-injection.md`.
+
 ## [0.1.23] - 2025-10-10
 ### Added
 - Introduced a coordinated shutdown pipeline that flushes event dispatcher queues,

--- a/Dev_Logic/Implemented_logic/2025-10-10-sentinel-failure-injection.md
+++ b/Dev_Logic/Implemented_logic/2025-10-10-sentinel-failure-injection.md
@@ -1,0 +1,42 @@
+# Sentinel Failure Injection Checklist (v0.1.0)
+
+## Purpose
+Document manual procedures for exercising newly instrumented sentinel failure modes: Codex bridge loss, sandbox configuration corruption, and repeated regression detection.
+
+## Preconditions
+- ACAGi desktop running on Windows with Codex bridge available.
+- Access to `acagi.ini` and task bucket fixtures.
+- Event console (Error Console dock) visible to observe sentinel notices.
+
+## Bridge Loss Simulation
+1. Launch Codex bridge via **Start Codex + Bridge**.
+2. Once the LED turns green, forcibly terminate the Codex console process (e.g., Task Manager → End task).
+3. Observe expectations:
+   - Bridge LED transitions to red.
+   - System notice: `[Sentinel:ui.terminal] Codex bridge connection lost…`.
+   - High-contrast dialog summarises recovery steps.
+   - `system.sentinel` event payload includes `kind="bridge.loss"` and `bridge_running=false`.
+4. Restart bridge and confirm sentinel alerts clear after successful reconnect.
+
+## Sandbox Corruption Simulation
+1. Close ACAGi.
+2. Edit `%APPDATA%/ACAGi/acagi.ini`, set `[mode] sandbox = chaos`.
+3. Relaunch ACAGi.
+4. Confirm expectations:
+   - Sentinel dialog and log entry referencing sandbox corruption.
+   - Runtime sandbox resets to `restricted` in status bar.
+   - Settings dialog shows corrected profile after reopening and saving.
+5. Restore file with a valid sandbox value when finished.
+
+## Repeated Regression Simulation
+1. Seed a task bucket fixture capable of toggling between `complete` and `in-progress` statuses via event bus mock or manual JSON edits.
+2. Publish alternating status updates (`complete` → `blocked` → `complete` → `blocked`) within 15 minutes using `tools/codex_pr_sentinel.py` helper scripts or the log observatory injection console.
+3. Observe expectations:
+   - Sentinel monitor logs `regression` immune responses.
+   - After the second rollback within the window, a `regression.repeat` sentinel dialog surfaces recovery guidance.
+   - Event metadata includes regression count and window seconds for auditing.
+4. Reset task status to `complete` and verify no further alerts appear once the window expires.
+
+## Reporting
+- Capture screenshots of dialogs and save telemetry payloads to `logs/session_<date>.md`.
+- File regressions or false positives in `memory/logic_inbox.jsonl` for triage.

--- a/logs/session_2025-10-10.md
+++ b/logs/session_2025-10-10.md
@@ -1,0 +1,19 @@
+# Session Log — 2025-10-10
+
+## Objective
+Implement sentinel escalation for bridge loss, sandbox corruption, and repeated regressions while improving user-facing diagnostics.
+
+## Context Snapshot
+- Branch: work (detached from remote; `git diff origin/main...HEAD` unavailable — no origin remote configured).
+- Key modules: `ACAGi.py` (sentinel + terminal subsystems), `Dev_Logic/` for operational documentation.
+- Reference manuals reviewed: `AGENT.md`, `memory/codex_memory.json`, `memory/logic_inbox.jsonl`.
+
+## Notable References
+- `ACAGi.py`: Sentinel monitor hub (~L7000), terminal health state handling (~L16680), status bar sandbox reporting (~L20220).
+
+## Suggested Next Coding Steps
+1. Draft helper for emitting sentinel failure events that log, publish, and surface recovery guidance.
+2. Integrate bridge loss and sandbox corruption detectors with LED updates, dialogs, and sentinel dispatch.
+3. Enhance regression watcher to escalate repeated rollbacks and annotate logs/prompts.
+4. Produce manual failure-injection checklist document and update CHANGELOG + memory as required.
+5. Run `python -m compileall ACAGi.py` and capture results for verification.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -48,6 +48,11 @@
       "applies_to": "safety-monitoring"
     },
     {
+      "title": "Sentinel Event Broadcasts",
+      "summary": "system.sentinel events capture bridge loss, sandbox corruption repairs, and repeated regressions; UI consumers must replay sentinel_history_payloads() on startup to surface pending alerts.",
+      "applies_to": "safety-monitoring"
+    },
+    {
       "title": "Operation Policy Enforcement",
       "summary": "SafetyManager consumes policies.json to enforce coder/test allowlists, denylists, approval prompts, and sandbox requirements via run_checked helpers.",
       "applies_to": "operation-safety"


### PR DESCRIPTION
## Summary
- broadcast structured `system.sentinel` events for bridge loss, sandbox corruption repair, and repeated regression loops with bounded history replay
- subscribe the terminal UI to sentinel alerts so LED transitions trigger high-contrast dialogs, system notices, and detailed logging with recovery steps
- document manual failure-injection procedures, update the changelog, and capture session context plus memory guidance

## Testing
- python -m compileall ACAGi.py

## Risk
- Moderate: sentinel wiring touches terminal health transitions and monitor backoff handling; validated via compile-only checks.

## Next Steps
- Automate regression staging tests so sentinel alerts can be triggered from CI fixtures.


------
https://chatgpt.com/codex/tasks/task_e_68deff5bb5908328832e436145dd64bd