### PR TITLE
feat: surface sentinel telemetry for self-implementation mode

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,4 +1,4 @@
-# ACAGi Codex Operating Manual (v0.1.0)
+# ACAGi Codex Operating Manual (v0.1.1)
 
 ## Mission Charter
 - Codify an extensible, local-first autonomous workspace for ACAGi.
@@ -35,6 +35,18 @@
 - Each module defines a `main()` entry point guarded by `if __name__ == "__main__":` when runnable.
 - Never wrap imports in `try/except` blocks.
 - Maintain 88-character line limit (Black-compatible) unless explicit reason documented in code comments.
+
+## Autonomous Operation Guidelines
+- The status bar **Self-Implementation Mode** toggle must only be used when
+  sentinel policies for `self_impl` remain in force (single parallel slot,
+  900 s max duration, no network access).
+- Always monitor the Log Observatory for `autonomy.self_impl` events and ensure
+  session notes capture every autonomous cycle.
+- If sentinel emits `autonomy.energy_quota` or `autonomy.loop_detected`, leave
+  the mode paused, investigate root cause, and document findings in the current
+  session log before re-enabling automation.
+- Update documentation and durable memory whenever Self-Implementation behaviour
+  changes so operators retain a tested runbook.
 
 ## Commit Protocol
 1. Sync with `origin/main` (fetch + rebase) before modifications whenever a remote exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,28 @@
 # Changelog
+## [0.1.27] - 2025-10-12
+### Added
+- Introduced a status bar **Self-Implementation Mode** toggle that wires a new
+  autonomy controller into the Rationalizer, task bucket pipeline, and sentinel
+  event streams.
+- Added telemetry publishing on `autonomy.self_impl` and appended session notes
+  for every autonomous cycle so operators can audit generated tasks.
+
+### Changed
+- Updated `policies.json` with a dedicated `self_impl` operation enforcing
+  serialized execution, 900 s watchdogs, and network denial; sentinel events now
+  pause the mode on quota or loop violations.
+- Documented the new workflow and manual observation steps in `README.md` and
+  refreshed status panel UX to surface the toggle state.
+- Emitted explicit `autonomy.self_impl` sub-events when sentinel policies pause
+  the controller so observers can correlate cycle history with energy or loop
+  enforcement in real time.
+
+### Validation
+- `python -m compileall ACAGi.py`
+- Manual: enable Self-Implementation Mode, observe `autonomy.self_impl` and
+  sentinel events in the Log Observatory, and confirm the status bar pauses when
+  energy or loop policies trigger.
+
 ## [0.1.26] - 2025-10-12
 ### Added
 - Introduced reusable helpers to load and persist `policies.json`, regenerating

--- a/README.md
+++ b/README.md
@@ -52,7 +52,40 @@ pip install -r requirements.txt
 
 ## Usage
 
-[Provide basic usage instructions or code examples here.]
+### Self-Implementation Mode
+
+The status bar now exposes a **Self-Implementation Mode** toggle that enables
+ACAGi to autonomously survey durable memory, dataset anchors, and the logic
+inbox. When active, the controller dispatches Rationalizer intent segmentation
+jobs, spawns exploratory task buckets, and appends a session note summarising
+every cycle.
+
+Sentinel policies remain in control of energy quotas and loop detection:
+
+- `policies.json` defines a `self_impl` operation with a single concurrent slot,
+  a 900 s watchdog, and denied network access.
+- The controller emits `autonomy.energy_quota` and `autonomy.loop_detected`
+  sentinel events whenever quotas or digest repeats trigger a pause.
+- The status bar button is disabled automatically when Sentinel blocks further
+  cycles.
+
+#### Manual Observation Steps
+
+1. Launch ACAGi and open the **Log Observatory** dock to tail the shared log.
+2. Toggle **Self-Implementation** on from the status bar telemetry panel.
+3. Monitor the log for `autonomy.self_impl` events that describe survey inputs,
+   generated bucket IDs, and associated task anchors. Expect additional
+   sub-events (`energy_violation`, `loop_violation`, `sentinel_blocked`) when
+   the controller pauses itself.
+4. Inspect the **system.sentinel** feed (Log Observatory or chat stream) for
+   `autonomy.energy_quota` or `autonomy.loop_detected` warnings. The status bar
+   button will pause automatically and surface the sentinel reason when a
+   violation fires.
+5. Review `logs/session_<date>.md` for the appended session note summarising
+   each Self-Implementation cycle and sentinel pause.
+
+Disable the toggle to return to manual control or investigate sentinel
+warnings before re-enabling autonomous cycles.
 
 ## Contributing
 

--- a/logs/session_2025-10-02.md
+++ b/logs/session_2025-10-02.md
@@ -294,3 +294,47 @@
 - Internal prompt: "Wire policy read/write helpers, enforce max_duration/parallel/network controls in SafetyManager+run_checked, and document sentinel-driven validation before exercising compileall."
 - After implementing enforcement, craft automated sentinel smoke tests that mock `emit_sentinel_event` to assert we log the expected metadata for parallel-limit and timeout breaches.
 - Consider exposing a UI affordance for policy editing that leverages the new helper functions while logging override actions to the session stream.
+
+## Session Update — 2025-10-02 (Self-Implementation Sentinel Telemetry)
+
+### Objective
+- Surface sentinel-driven pauses on the `autonomy.self_impl` stream and tighten
+  documentation so operators can observe Self-Implementation Mode without
+  guesswork.
+
+### Context
+- Re-read `AGENT.md`, `memory/codex_memory.json`, and
+  `memory/logic_inbox.jsonl` to reaffirm verbose logging, changelog, and session
+  capture mandates before touching ACAGi.
+- Captured the required context snapshot: `git status -sb`,
+  `git log -n 10 --oneline`, and `git fetch --all --prune`. Attempting
+  `git rebase origin/main` still reports `invalid upstream 'origin/main'` because
+  the repository has no remote configured.
+- Confirmed the Self-Implementation controller already emits autonomy events but
+  lacked explicit telemetry when sentinel policies pause cycles, making manual
+  observation steps harder to narrate.
+
+### Actions
+- Added `sentinel_blocked`, `energy_violation`, and `loop_violation` payloads to
+  the Self-Implementation controller so sentinel enforcement appears on the
+  `autonomy.self_impl` bus alongside warning logs.
+- Extended README manual observation guidance with the new sub-events and noted
+  that the status bar surfaces sentinel pause reasons.
+- Updated `CHANGELOG.md` to capture the telemetry refinements and executed
+  `python -m compileall ACAGi.py` to confirm the file compiles cleanly.
+
+### Suggested Next Coding Steps
+- Internal prompt: "Backfill automated coverage for the new
+  Self-Implementation sentinel sub-events and assert the status bar updates when
+  they publish; rehearse manual checks via the Log Observatory."
+- Draft sentinel smoke tests that mock `emit_sentinel_event`/`publish` to ensure
+  `sentinel_blocked` and violation payloads mirror sentinel metadata.
+- Explore capturing the most recent sentinel violation in durable memory so
+  operators can review pause history outside the live log stream.
+
+### Manual Observation Notes
+- Start Self-Implementation Mode, then watch `autonomy.self_impl` for
+  `energy_violation`, `loop_violation`, or `sentinel_blocked` events that match
+  sentinel warnings.
+- Confirm the status bar toggle disables itself and displays the sentinel reason
+  when those events fire.

--- a/logs/session_2025-10-12.md
+++ b/logs/session_2025-10-12.md
@@ -1,0 +1,26 @@
+# Session Log — 2025-10-12
+
+## Objective
+Implement a Self-Implementation Mode toggle that empowers ACAGi to autonomously iterate via Rationalizer workflows while keeping Sentinel quota and loop protections active, along with documentation and validation updates.
+
+## Context Snapshot
+- Branch: work (no remotes configured; `git fetch`/`origin/main` sync unavailable).
+- Reviewed manuals: `AGENT.md`, `memory/codex_memory.json`, `memory/logic_inbox.jsonl`, latest session log.
+- Key constraints: must add verbose inline commentary, update durable documentation (CHANGELOG, README), refresh memory lessons as needed, and record manual verification guidance.
+
+## Notable References
+- `ACAGi.py`: MainWindow setup (~L20940+), StatusBarTelemetryPanel (~L20560+), RationalizerManager (~L5826+), Task bucket orchestration (~L14800+), Sentinel safety controls (~L17000+).
+- `CHANGELOG.md`: document behavioral deltas.
+- `README.md`: home for operator guidance.
+- `memory/codex_memory.json`: repository-wide durable lessons repository.
+
+## Suggested Next Coding Steps
+1. Draft an internal development prompt clarifying expected UI placement, Rationalizer automation hooks, Sentinel policy enforcement, and validation strategy; capture acceptance criteria for logging, quotas, and loop detection.
+2. Extend `StatusBarTelemetryPanel` (or adjacent UI control layer) with a Self-Implementation Mode button, wiring it through MainWindow to an autonomy coordinator that orchestrates Rationalizer surveys, task bucket spawning, and learning persistence.
+3. Introduce the autonomy coordinator implementation: leverage Rationalizer manager APIs to run continuous surveys, interact with dataset/memory services, and publish results back through existing storage routines. Ensure Sentinel integration clamps energy quotas and halts automation when policy violations or loop patterns surface.
+4. Update documentation artifacts (README, CHANGELOG, memory lessons) with usage instructions and manual observation steps; mention Sentinel safeguards and operator expectations.
+5. Run `python -m compileall ACAGi.py`, capture results, and describe manual observation instructions in the session log & PR testing section.
+
+## Validation Plan
+- `python -m compileall ACAGi.py`
+- Manual observation: Launch ACAGi, toggle Self-Implementation Mode, monitor the Log Observatory for `autonomy.self_impl` events, confirm Sentinel quota/loop alerts appear in the status panel and automation pauses upon breach.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "last_updated": "2025-10-11",
+  "last_updated": "2025-10-12",
   "stable_lessons": [
     {
       "title": "Verbose Implementation Standard",
@@ -124,6 +124,15 @@
       "metadata": {
         "introduced": "2025-10-11",
         "notes": "Ensure new inbox entries include action/topic metadata when special handling is required."
+      }
+    },
+    {
+      "title": "Self-Implementation Sentinels",
+      "summary": "Self-Implementation Mode emits autonomy.self_impl telemetry, including sentinel_blocked/energy_violation/loop_violation events, obeys the self_impl policy guard, pauses when sentinel warnings fire, and records each cycle in the session log.",
+      "applies_to": "autonomy",
+      "metadata": {
+        "introduced": "2025-10-12",
+        "notes": "Monitor the Log Observatory and sentinel feeds whenever the status bar toggle is active; the status bar now mirrors sentinel pause reasons."
       }
     },
     {

--- a/policies.json
+++ b/policies.json
@@ -105,6 +105,36 @@
           "wget"
         ]
       }
+    },
+    "self_impl": {
+      "allow": [],
+      "deny": [],
+      "approval": [],
+      "sandbox_modes": [
+        "isolated",
+        "restricted"
+      ],
+      "notes": "Self-Implementation Mode cycles must remain serialized and offline to avoid runaway automation.",
+      "limits": {
+        "max_duration_seconds": 900,
+        "max_parallel_tasks": 1,
+        "network": "deny",
+        "network_blocklist": [
+          "aria2c",
+          "curl",
+          "ftp",
+          "netcat",
+          "nc",
+          "ping",
+          "rsync",
+          "scp",
+          "sftp",
+          "ssh",
+          "telnet",
+          "traceroute",
+          "wget"
+        ]
+      }
     }
   },
   "metadata": {


### PR DESCRIPTION
## Summary
- publish `sentinel_blocked`, `energy_violation`, and `loop_violation` events from the Self-Implementation controller so sentinel pauses surface on the autonomy bus
- document the new telemetry in the README, changelog, memory store, and session log for operator playbooks

## Testing
- python -m compileall ACAGi.py

## Risk
- Low: telemetry-only updates that do not alter task scheduling logic.

## Next Steps
- add automated coverage that exercises the new sentinel sub-events and status bar updates.


------
https://chatgpt.com/codex/tasks/task_e_68df0875e1688328b832dd655528bc0c