### PR TITLE
Hoist logging constants ahead of SafetyManager init

### DIFF
--- a/ACAGi.py
+++ b/ACAGi.py
@@ -207,6 +207,25 @@ DEV_LOGIC_ROOT = Path(__file__).resolve().parent / "Dev_Logic"
 
 
 # ============================================================================
+# Global Application Constants
+# ============================================================================
+
+# Centralise the logging identifiers near the top of the module so any
+# subsystem initialisers (notably SafetyManager) can safely reference them
+# during import time without risking NameError exceptions.
+APP_NAME = "Agent Virtual Desktop — Codex-Terminal"
+VD_LOGGER_NAME = "VirtualDesktop"
+VD_LOG_FILENAME = "vd_system.log"
+VD_LOG_PATH: Path = Path()
+MEMORY_SERVICES: "MemoryServices" | None = None
+Excepthook = Callable[
+    [type[BaseException], BaseException, Optional[TracebackType]],
+    None,
+]
+_ORIGINAL_EXCEPTHOOK: Optional[Excepthook] = None
+
+
+# ============================================================================
 # Token Budget Utilities (Inlined from Dev_Logic/token_budget.py)
 # ============================================================================
 
@@ -1817,18 +1836,6 @@ class RepositoryIndex:
 # ============================================================================
 # Boot & Environment
 # ============================================================================
-
-APP_NAME = "Agent Virtual Desktop — Codex-Terminal"
-VD_LOGGER_NAME = "VirtualDesktop"
-VD_LOG_FILENAME = "vd_system.log"
-VD_LOG_PATH: Path = Path()
-MEMORY_SERVICES: MemoryServices | None = None
-Excepthook = Callable[
-    [type[BaseException], BaseException, Optional[TracebackType]],
-    None,
-]
-_ORIGINAL_EXCEPTHOOK: Optional[Excepthook] = None
-
 
 def _ensure_high_dpi_rounding_policy() -> None:
     """Apply pass-through DPI rounding before any QApplication is created."""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## [0.1.28] - 2025-10-13
+### Changed
+- Hoisted `APP_NAME`, `VD_LOGGER_NAME`, and log sink constants to the top of
+  `ACAGi.py` so `SafetyManager` and other boot-time subsystems can initialise
+  loggers without encountering `NameError` exceptions during module import.
+- Recorded the associated session plan in `logs/session_2025-10-13.md` for
+  traceability per governance requirements.
+
+### Validation
+- `python -m compileall ACAGi.py`
+
 ## [0.1.27] - 2025-10-12
 ### Added
 - Introduced a status bar **Self-Implementation Mode** toggle that wires a new

--- a/logs/session_2025-10-13.md
+++ b/logs/session_2025-10-13.md
@@ -1,0 +1,28 @@
+# Session Log — 2025-10-13
+
+## Objective
+- Address NameError risk in SafetyManager initialization by ensuring logging constants are defined before use and validate module compilation.
+
+## Context Snapshot
+- git status: clean working tree on branch `work`.
+- git log (last 10): captured for reference.
+- git diff origin/main...HEAD: failed because `origin/main` is unavailable in this offline workspace.
+- git fetch --all --prune: executed (no remotes configured).
+- git rebase origin/main: failed (`origin/main` missing).
+
+## Files of Interest
+- `ACAGi.py` — SafetyManager logging constants ordering.
+
+## Suggested Next Coding Steps
+1. Inspect `ACAGi.py` to locate logging constants and the `SafetyManager` constructor usage.
+2. Decide between moving constant definitions or injecting logger name parameter; ensure constructor references resolved.
+3. Update global `safety_manager` initialization to reference the refactored constant or explicit parameter.
+4. Run `python -m compileall ACAGi.py` to confirm module imports cleanly.
+5. Prepare commit and PR summary once tests pass.
+
+## Outstanding Questions
+- None identified.
+
+## Follow-up Opportunities
+- Consider adding unit tests around SafetyManager logging initialization in future work.
+

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -139,6 +139,11 @@
       "title": "Coordinated Shutdown Procedure",
       "summary": "Use the ShutdownCoordinator to flush event queues, persist durable memory stores, and append a session summary; crash handlers now call it so new services should follow the same pattern when registering exit hooks.",
       "applies_to": "acagi-runtime"
+    },
+    {
+      "title": "Logger Constant Ordering",
+      "summary": "Define module-level logging identifiers before constructing classes that reference them at import time so SafetyManager and similar boot guards can initialise without NameError exceptions.",
+      "applies_to": "logging-initialisation"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- Move the application logging constants ahead of SafetyManager so import-time logger setup no longer risks NameError exceptions
- Update governance artifacts with the session log entry and changelog/memory notes documenting the ordering change

## Testing
- python -m compileall ACAGi.py

## Risk
- Low: reorder of constants and documentation updates only

## Next Steps
- Consider backfilling unit coverage for SafetyManager logger initialisation


------
https://chatgpt.com/codex/tasks/task_e_68df1e2ae1e08328a48af5df93486934