### PR TITLE
Fix remote access boot order for ACAGi startup

### DIFF
--- a/ACAGi.py
+++ b/ACAGi.py
@@ -4155,14 +4155,6 @@ def remote_access_snapshot() -> RemoteAccessSnapshot:
     return remote_access_controller().snapshot()
 
 
-if REMOTE_ACCESS is None:
-    REMOTE_ACCESS = RemoteAccessController(
-        EVENT_DISPATCHER,
-        safety_manager,
-        RUNTIME_SETTINGS,
-    )
-
-
 def _dataset_root(candidate: Optional[Path]) -> Path:
     return Path(candidate) if candidate else TASKS_DATA_ROOT
 
@@ -4704,6 +4696,17 @@ EVENT_DISPATCHER = EventDispatcher(
     wildcard_topic=_WILDCARD_TOPIC,
     logger=logging.getLogger(f"{VD_LOGGER_NAME}.events"),
 )
+
+
+if REMOTE_ACCESS is None:
+    # Initialise the remote access controller only after the dispatcher exists.
+    # This preserves import order so Codex Terminal and Virtual Desktop wiring
+    # stays intact during startup.
+    REMOTE_ACCESS = RemoteAccessController(
+        EVENT_DISPATCHER,
+        safety_manager,
+        RUNTIME_SETTINGS,
+    )
 
 
 def register_topic(topic: str) -> None:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## [0.1.29] - 2025-10-14
+### Fixed
+- Reordered `RemoteAccessController` initialisation to occur after the event
+  dispatcher is created so ACAGi boots without raising `NameError` and the
+  Codex Terminal / Virtual Desktop wiring stays intact.
+- Logged session context in `logs/session_2025-10-14.md` to document the
+  remediation path and uphold archival policy.
+
+### Validation
+- `python -m py_compile ACAGi.py`
+
 ## [0.1.28] - 2025-10-13
 ### Changed
 - Hoisted `APP_NAME`, `VD_LOGGER_NAME`, and log sink constants to the top of

--- a/logs/session_2025-10-14.md
+++ b/logs/session_2025-10-14.md
@@ -1,0 +1,41 @@
+# Session Log — 2025-10-14
+
+## Objective
+- Restore ACAGi.py launch flow so that the environment boots, Codex Terminal surfaces correctly, and the Virtual Desktop dock plan remains intact.
+- Resolve the `NameError` raised for `EVENT_DISPATCHER` during remote access controller initialisation.
+
+## Context Snapshot
+- git status: clean working tree on branch `work` (`git status -sb`).
+- git log: recent merges from GitHub fetched into local branch (`git log -n 10 --oneline`).
+- git remote: no remotes configured in the container; unable to sync with `origin/main` (documented limitation).
+- git diff origin/main...HEAD: not executable without remote; defer until remote is available.
+
+## Context Review
+- Reviewed `AGENT.md` (v0.1.1) to reaffirm verbose implementation, documentation sync, and session logging mandates.
+- Consulted `memory/codex_memory.json` for lessons on dispatcher telemetry, boot environment, terminal UI, and virtual desktop integration expectations.
+- Examined `memory/logic_inbox.jsonl`; pending directives remain open (sentinel runbook, Dev Logic template, settings dialog exposure, policy tests).
+- Surveyed `Dev_Logic/` to understand assets for Codex Terminal and Virtual Desktop to ensure stylistic continuity.
+
+## Key Artifacts / References
+- `ACAGi.py`: monolithic application orchestrator experiencing launch regression.
+- `Codex_Terminal.py`: reference for terminal desktop styling and behaviour.
+- `Dev_Logic/Virtual_Desktop.py`: prior implementation slated for embedding into ACAGi runtime.
+
+## Suggested Next Coding Steps
+1. Trace module-level initialisation order within `ACAGi.py` to locate forward references leading to the `EVENT_DISPATCHER` NameError.
+2. Reorder or refactor initialisation so dispatcher instantiation precedes remote access bootstrap while keeping documentation and comments verbose.
+3. Validate that Codex Terminal and Virtual Desktop integration hooks remain referenced after adjustments; ensure no regressions to planned embedding points.
+4. Update documentation artifacts (`CHANGELOG.md`, session log) if launch flow changes are material.
+5. Execute available sanity checks (syntax, targeted tests) to confirm the application imports successfully.
+
+## Open Questions / Risks
+- Need to ensure moving dispatcher initialisation does not break other sections expecting late binding or module-level side effects.
+- Confirm whether additional startup dependencies rely on the original ordering; update memory or inbox if new follow-up tasks emerge.
+
+## Pending Inbox Items Impact
+- No direct progress on outstanding logic inbox tasks; monitor for future opportunities while focusing on launch restoration.
+
+## Work Notes
+- Session initiated in offline container; remote sync steps recorded as blocked due to missing remotes.
+- Context gathered from governance documents and Dev_Logic assets to preserve canonical styling for Codex Terminal and Virtual Desktop components.
+

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "last_updated": "2025-10-12",
+  "last_updated": "2025-10-14",
   "stable_lessons": [
     {
       "title": "Verbose Implementation Standard",
@@ -144,6 +144,11 @@
       "title": "Logger Constant Ordering",
       "summary": "Define module-level logging identifiers before constructing classes that reference them at import time so SafetyManager and similar boot guards can initialise without NameError exceptions.",
       "applies_to": "logging-initialisation"
+    },
+    {
+      "title": "Remote Access Dispatcher Boot Order",
+      "summary": "Instantiate the RemoteAccessController only after the EventDispatcher is available so module import order keeps Codex Terminal and Virtual Desktop integrations stable and prevents NameError exceptions during startup.",
+      "applies_to": "remote-control"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- initialise the RemoteAccessController after the EventDispatcher so ACAGi can import without raising NameError and the Codex Terminal / Virtual Desktop wiring stays intact
- document the remediation in the changelog, structured memory, and the 2025-10-14 session log per governance requirements

## Testing
- python -m py_compile ACAGi.py

## Risk
- Low; changes only adjust module initialisation order and related documentation.

## Next Steps
- Proceed with embedding the Virtual Desktop implementation into ACAGi once remote wiring validation is complete.


------
https://chatgpt.com/codex/tasks/task_e_68df211e50c48328815e77cc8f58bd8b