### PR TITLE
Fix graceful fallback when PySide6 is unavailable

### DIFF
--- a/ACAGi.py
+++ b/ACAGi.py
@@ -11,9 +11,6 @@ Windows 10+ for the bridge runtime.
 
 from __future__ import annotations
 
-from PySide6.QtGui import QGuiApplication
-from PySide6.QtCore import Qt
-
 import argparse
 import ast
 import audioop
@@ -76,7 +73,7 @@ from typing import (
 
 # Optional dependencies are resolved via runtime checks instead of guarded imports
 _REQUESTS_MODULE_NAME = "requests"
-_PILLOW_MODULE_NAME = "PIL.Image"
+_PILLOW_MODULE_NAME = "PIL"
 _NUMPY_MODULE_NAME = "numpy"
 _SOUNDDEVICE_MODULE_NAME = "sounddevice"
 _PYTTSX3_MODULE_NAME = "pyttsx3"
@@ -112,7 +109,36 @@ if importlib.util.find_spec(_WHISPER_MODULE_NAME):
 else:
     whisper = None  # type: ignore[assignment]
 
+_PYSIDE6_MODULE_NAME = "PySide6"
+
+if importlib.util.find_spec(_PYSIDE6_MODULE_NAME) is None:
+    def _main_missing_pyside6() -> int:
+        """Emit a clear bootstrap error when PySide6 is unavailable.
+
+        The governance charter requires graceful handling of optional
+        dependencies. Instead of allowing the interpreter to raise a
+        `ModuleNotFoundError`, we log the corrective steps so operators can
+        install GUI requirements or fall back to headless automation flows.
+        """
+
+        logging.basicConfig(level=logging.INFO)
+        logger = logging.getLogger("acagi.bootstrap")
+        logger.error(
+            "PySide6 is not installed, preventing the ACAGi desktop from launching."
+        )
+        logger.info(
+            "Install PySide6>=6.6 (e.g. `pip install PySide6`) or run headless"
+            " automation commands via Codex_Terminal.py."
+        )
+        return 1
+
+    _EXIT_CODE = _main_missing_pyside6()
+    if __name__ == "__main__":
+        sys.exit(_EXIT_CODE)
+    raise SystemExit(_EXIT_CODE)
+
 from PySide6.QtCore import (
+    Qt,
     QRect,
     QRectF,
     QTimer,
@@ -134,6 +160,7 @@ from PySide6.QtGui import (
     QColor,
     QCursor,
     QDesktopServices,
+    QGuiApplication,
     QFont,
     QKeyEvent,
     QKeySequence,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## [0.1.33] - 2025-10-17
+### Fixed
+- Added a boot-time PySide6 availability guard that logs installation guidance
+  instead of throwing `ModuleNotFoundError`, allowing headless workflows to
+  continue running automation helpers.
+
+### Validation
+- `python ACAGi.py` *(logs missing PySide6 guidance; exits with code 1)*
+- `python -m py_compile ACAGi.py`
+
 ## [0.1.32] - 2025-10-16
 ### Fixed
 - Hardened the high-DPI rounding policy guard so embedded Qt hosts log and skip

--- a/logs/session_2025-10-03.md
+++ b/logs/session_2025-10-03.md
@@ -43,3 +43,48 @@
 - `python tools/logic_inbox.py validate memory/logic_inbox.jsonl`
 - `flake8` *(missing; command unavailable in container)*
 
+
+---
+
+## Session Entry – 2025-10-17 (Follow-up Investigation)
+
+### Objective
+- Diagnose why the primary launch script fails to start and restore a working startup sequence for `ACAGi.py`.
+- Ensure all governance prerequisites are met (context capture, logging, testing) while addressing the launch regression.
+- Document findings, update durable memory if new lessons emerge, and prepare a merge-ready branch.
+
+### Context Review Highlights
+- Revisited `AGENT.md` v0.1.1 for verbose implementation and testing mandates.
+- Parsed `memory/codex_memory.json` to reconfirm boot environment lessons (BootEnvironment manager, high-DPI guard) relevant to startup issues.
+- Checked `memory/logic_inbox.jsonl`; existing dispatched items remain untouched for this session.
+- Attempted `git diff origin/main...HEAD` per protocol; noted failure because `origin/main` is unavailable in the container (no remote configured).
+
+### Self-Prompt & Suggested Next Coding Steps
+1. Reproduce the launch failure by executing the documented entry point (`python ACAGi.py`) and capture stack traces.
+2. Inspect `ACAGi.py` initialization flow—especially BootEnvironment and Qt setup—for missing guards or incorrect ordering.
+3. Cross-reference supporting modules (`Codex_Terminal.py`, `Agent_Codex_Standalone/`, `Dev_Logic/`) for dependencies invoked during launch.
+4. Implement corrective changes with rich inline commentary, ensuring optional dependencies remain gracefully handled.
+5. Run available tests or at minimum `python -m py_compile` on touched modules; log unavailable tooling.
+6. Update `CHANGELOG.md` and prepare PR narrative via `make_pr`.
+
+### Open Questions / Risks
+- Does the crash stem from Qt platform plugin issues in headless environments? Need to confirm environment variables.
+- Are there stale imports referencing removed modules during prior refactors?
+
+### TODO Mirror
+- If the fix requires follow-up automation (e.g., sentinel tests), add new entries to `memory/logic_inbox.jsonl` before session close.
+
+
+### Execution Notes
+- Observed `ModuleNotFoundError: PySide6` when launching `python ACAGi.py`.
+- Added an import-time guard using `importlib.util.find_spec` to log actionable
+  installation instructions and exit cleanly when PySide6 is unavailable.
+- Adjusted optional dependency detection for Pillow to probe the base `PIL`
+  package, preventing `ModuleNotFoundError` cascades during the guard checks.
+- Updated `CHANGELOG.md` (v0.1.33) and appended a stable lesson to
+  `memory/codex_memory.json` documenting the new PySide6 bootstrap policy.
+
+### Validation
+- `python ACAGi.py` *(logs PySide6 guidance; returns exit code 1)*
+- `python -m py_compile ACAGi.py`
+

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -193,6 +193,16 @@
         "introduced": "2025-10-16",
         "notes": "Fallback on environment variables when the guard detects an existing Qt instance."
       }
+    },
+    {
+      "id": "pyside6-bootstrap-guard",
+      "title": "PySide6 Bootstrap Guard",
+      "summary": "ACAGi.py now checks for PySide6 at import time and logs installation guidance before exiting so headless automation remains usable when the GUI dependency is missing.",
+      "applies_to": "acagi-boot",
+      "metadata": {
+        "introduced": "2025-10-17",
+        "notes": "Re-run `pip install PySide6` or leverage Codex_Terminal.py for CLI workflows when the guard triggers."
+      }
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- add an import-time PySide6 availability guard that logs installation guidance and exits cleanly
- adjust the Pillow capability probe to avoid raising ModuleNotFoundError while optional dependencies are missing
- record the bootstrap policy in the changelog, durable memory, and session log per governance requirements

## Testing
- python ACAGi.py
- python -m py_compile ACAGi.py

------
https://chatgpt.com/codex/tasks/task_e_68df420646548328babca4eeafa166cb