### PR TITLE
fix: embed terminal desktop on ACAGi launch

### DIFF
--- a/ACAGi.py
+++ b/ACAGi.py
@@ -21996,7 +21996,14 @@ class MainWindow(QMainWindow):
 
         self.desktop: Optional[TerminalDesktop] = None
         self.chat = ChatCard(self.theme, self.ollama, self.settings, self.lex_mgr, self)
-        self.setCentralWidget(self.chat)
+        # The standalone launch path mirrors Codex_Terminal by wrapping the chat
+        # card in the draggable Terminal Desktop canvas so operators land in the
+        # familiar virtual desktop instead of a bare chat widget.
+        if self._embedded:
+            self.setCentralWidget(self.chat)
+        else:
+            self.desktop = TerminalDesktop(self.theme, self.chat, self)
+            self.setCentralWidget(self.desktop)
         self.dataset_dock = DatasetManagerDock(self.chat, self)
         self.addDockWidget(Qt.RightDockWidgetArea, self.dataset_dock)
         self.dataset_dock.hide()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## [0.1.34] - 2025-10-17
+### Fixed
+- Updated the ACAGi main window to embed the chat view inside the draggable
+  Terminal Desktop canvas when running standalone so startup mirrors the
+  Codex Terminal experience instead of displaying a bare chat pane.
+
+### Validation
+- `python -m py_compile ACAGi.py`
+
 ## [0.1.33] - 2025-10-17
 ### Fixed
 - Added a boot-time PySide6 availability guard that logs installation guidance

--- a/logs/session_2025-10-17.md
+++ b/logs/session_2025-10-17.md
@@ -1,0 +1,28 @@
+# Session Log — 2025-10-17
+
+## Objective
+- Update `ACAGi.py` so that launching the script embeds the terminal within its dedicated virtual desktop, mirroring `Codex_Terminal.py` behaviour.
+
+## Context Snapshot
+- git status → clean working tree on branch `work`.
+- git log (10) reviewed for recent startup fixes.
+- `git diff origin/main...HEAD` failed because `origin/main` is unavailable in this workspace; noting as environment limitation.
+- Reviewed governance artefacts: `AGENT.md`, `memory/codex_memory.json`, `memory/logic_inbox.jsonl`.
+- Pending logic inbox items remain dispatched; none directly block this task.
+
+## File Notes
+- `ACAGi.py`: Needs boot adjustments so the terminal spawns inside ACAGi’s virtual desktop rather than an external console window.
+- `Codex_Terminal.py`: Reference implementation for the desired launch flow.
+
+## Suggested Next Coding Steps
+1. Inspect `Codex_Terminal.py` startup sequence to understand terminal docking.
+2. Modify `ACAGi.py` boot logic to instantiate the terminal inside its virtual desktop before showing the main window.
+3. Ensure high-DPI and PySide guards remain intact while integrating the terminal view.
+4. Run available sanity checks (likely manual launch via `python ACAGi.py` to confirm no crash).
+5. Update documentation (`CHANGELOG.md`) and durable memory if startup behaviour changes materially.
+
+## Open Questions
+- Does `ACAGi.py` already instantiate a Virtual Desktop dock that can host the terminal? Need to confirm while editing.
+
+## Follow-Up Todos
+- Revisit sentinel troubleshooting runbook task once UI stabilises.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -87,6 +87,12 @@
       "applies_to": "ui-virtual-desktop"
     },
     {
+      "id": "terminal-desktop-default-launch",
+      "title": "Terminal Desktop Default Launch",
+      "summary": "Standalone launches of ACAGi should wrap the chat card in the Terminal Desktop canvas so operators land inside the virtual desktop layout instead of a bare chat view.",
+      "applies_to": "acagi-boot"
+    },
+    {
       "id": "brain-map-dock",
       "title": "Brain Map Dock",
       "summary": "ACAGi includes a BrainMapDock that lazily renders Hippocampus nodes and typed edges with energy/salience overlays and Dev Space focus callbacks when nodes are selected.",


### PR DESCRIPTION
## Summary
- embed the chat card inside the Terminal Desktop when ACAGi launches standalone so the UX mirrors Codex-Terminal
- record the behaviour change in the changelog, durable memory, and a dated session log for governance traceability

## Testing
- python -m py_compile ACAGi.py

## Risk
- Low: UI startup wiring change that selects the Terminal Desktop container when not embedded.

## Next Steps
- Exercise the launch flow on a GUI-capable host to confirm the Terminal Desktop renders as expected.


------
https://chatgpt.com/codex/tasks/task_e_68dfc8cc74708328a3048b27fea78ba2