### PR TITLE
feat: enforce windows elevation before qt startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## [0.1.38] - 2025-10-18
+### Added
+- Introduced a Windows elevation helper that relaunches ACAGi with the
+  ``runas`` verb when administrative privileges are missing, guarding against
+  infinite recursion with the ``ACAGI_ELEVATED`` environment flag and logging
+  bootstrap decisions for operators.
+
+### Validation
+- `python -m compileall ACAGi.py`
+
 ## [0.1.37] - 2025-10-18
 ### Fixed
 - Reused ACAGi's guarded DPI helper inside `Codex_Terminal.py` so both

--- a/logs/session_2025-10-03.md
+++ b/logs/session_2025-10-03.md
@@ -1,3 +1,41 @@
+# Session Log — 2025-10-03 (Elevation Helper)
+
+## Objective
+- Implement Windows elevation helper for ACAGi.py startup per latest request.
+- Maintain repository governance artifacts (CHANGELOG, memory/inbox review).
+
+## Context Snapshot
+- Branch: `work` (no upstream configured).
+- `git status`: clean before changes.
+- `git log -n 10 --oneline`: captured recent history (see terminal chunk ca4449).
+- `git diff origin/main...HEAD`: unavailable because no `origin` remote is configured.
+- Remote configuration: `git remote -v` returned no remotes.
+- Dependencies: PySide6 expected but not installed in container; GUI launch not attempted this session.
+
+## Self-Prompt & Validation Plan
+- Add helper near entrypoint detecting Windows platform and checking elevation via `ctypes.windll.shell32.IsUserAnAdmin()`.
+- On missing elevation, relaunch with `ShellExecuteW` using `runas` verb, forwarding arguments and setting `ACAGI_ELEVATED=1` to avoid recursion; exit afterward.
+- Invoke helper at the top of `main()` before constructing the Qt application.
+- Update CHANGELOG and document code with rationale-rich comments.
+- Validation: run `python -m compileall ACAGi.py` to ensure syntax correctness; manual GUI test omitted (no PySide6).
+
+## Files of Interest
+- `ACAGi.py`: Windows elevation helper additions near entrypoint.
+- `CHANGELOG.md`: Document new behavior.
+
+## Logic Inbox Review
+- Pending (dispatched): Sentinel troubleshooting runbook, Dev Logic template, settings dialog work, settings loader tests/rebinding, sentinel enforcement tests.
+- Pending (new): Smoke test embedded Qt launch path — not addressed this session.
+
+## Suggested Next Coding Steps
+- After implementing helper, consider adding unit coverage for elevation guard when Windows CI environment available.
+- Follow up on `2025-10-18-001` inbox item with manual Qt launch verification in GUI-capable environment.
+
+## Outstanding Questions
+- None identified; Windows-specific behavior to be validated by operators on target OS.
+
+----
+
 # Session Log – 2025-10-03
 
 ## Objective


### PR DESCRIPTION
## Summary
- add a Windows elevation helper that relaunches ACAGi with the `runas` verb when admin privileges are missing
- invoke the helper at the start of `main()` before constructing the Qt application, using `ACAGI_ELEVATED` as a recursion guard
- document the elevation change in the changelog and session log per governance policy

## Testing
- python -m compileall ACAGi.py

## Risk
- Low: helper only runs on Windows hosts lacking elevation and bails out gracefully if shell32 is unavailable

## Next Steps
- Explore automated coverage for the elevation guard within a Windows-capable CI environment


------
https://chatgpt.com/codex/tasks/task_e_68e01ee1ef2c8328a934953a9b5c8386