### PR TITLE
Fix Windows elevation relaunch quoting

### DIFF
--- a/ACAGi.py
+++ b/ACAGi.py
@@ -22909,7 +22909,12 @@ def _ensure_windows_elevation(logger: Optional[logging.Logger] = None) -> None:
         "Administrative privileges required; relaunching ACAGi with elevation.",
     )
 
-    params = " ".join(sys.argv[1:])
+    # ``ShellExecuteW`` expects a single command-line string that mirrors the way
+    # Windows shells parse arguments. Building this value manually via string
+    # joins loses quoting for arguments that contain spaces or other shell
+    # metacharacters. ``subprocess.list2cmdline`` centralises those quoting
+    # semantics so any spaced argument survives the elevation hop intact.
+    params = subprocess.list2cmdline(sys.argv[1:])
     os.environ["ACAGI_ELEVATED"] = "1"
 
     try:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## [0.1.40] - 2025-10-19
+### Fixed
+- Updated the Windows elevation relaunch helper to build its command string
+  with ``subprocess.list2cmdline`` so arguments containing spaces survive the
+  privilege escalation hop without corruption.
+- Added a Windows-only regression test that validates spaced arguments remain
+  quoted when `_ensure_windows_elevation` reinvokes the interpreter.
+
+### Validation
+- `pytest Dev_Logic/tests/test_windows_elevation.py`
+
 ## [0.1.39] - 2025-10-18
 ### Added
 - Implemented an import-time dependency bootstrapper that auto-installs

--- a/Dev_Logic/tests/test_windows_elevation.py
+++ b/Dev_Logic/tests/test_windows_elevation.py
@@ -1,0 +1,125 @@
+"""Validate Windows elevation relaunch argument handling."""
+
+from __future__ import annotations
+
+import ast
+import ctypes
+import logging
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import Any, Callable, Dict, Tuple
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    # Pytest can change the working directory during collection; explicitly
+    # insert the repository root so ``import ACAGi`` resolves the monolithic
+    # entrypoint when tests run from nested paths.
+    sys.path.insert(0, str(REPO_ROOT))
+
+ACAGI_SOURCE = (REPO_ROOT / "ACAGi.py").read_text(encoding="utf-8")
+
+
+def _load_ensure_windows_elevation() -> Callable[[logging.Logger | None], None]:
+    """Compile `_ensure_windows_elevation` in isolation for targeted testing."""
+
+    module_ast = ast.parse(ACAGI_SOURCE)
+    for node in module_ast.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_ensure_windows_elevation":
+            isolated_module = ast.Module(body=[node], type_ignores=[])
+            compiled = compile(isolated_module, filename=str(REPO_ROOT / "ACAGi.py"), mode="exec")
+            namespace: Dict[str, Any] = {
+                "__name__": "test_windows_elevation",
+                "ctypes": ctypes,
+                "logging": logging,
+                "os": os,
+                "subprocess": subprocess,
+                "sys": sys,
+            }
+            exec(compiled, namespace)
+            return namespace["_ensure_windows_elevation"]
+
+    raise AssertionError("_ensure_windows_elevation function not found")
+
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("win"),
+    reason="Windows-only behaviour",
+)
+
+
+def _capture_shell32_invocation() -> Tuple[types.SimpleNamespace, Dict[str, Any]]:
+    """Create a fake ``shell32`` implementation that records relaunch calls."""
+
+    captured: Dict[str, Any] = {}
+
+    def _is_user_an_admin() -> int:
+        """Return ``0`` so the elevation branch executes during the test."""
+
+        return 0
+
+    def _shell_execute(
+        hwnd: Any,
+        operation: str,
+        executable: str,
+        parameters: str,
+        directory: Any,
+        show_cmd: int,
+    ) -> int:
+        """Record the invocation and emulate a successful relaunch result."""
+
+        captured["args"] = (
+            hwnd,
+            operation,
+            executable,
+            parameters,
+            directory,
+            show_cmd,
+        )
+        captured["params"] = parameters
+        return 33
+
+    fake_shell32 = types.SimpleNamespace(
+        IsUserAnAdmin=_is_user_an_admin,
+        ShellExecuteW=_shell_execute,
+    )
+    return fake_shell32, captured
+
+
+def test_elevation_relaunch_preserves_spaced_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the relaunch command keeps spaced arguments quoted on Windows."""
+
+    fake_shell32, captured = _capture_shell32_invocation()
+    monkeypatch.setattr(
+        ctypes,
+        "windll",
+        types.SimpleNamespace(shell32=fake_shell32),
+        raising=False,
+    )
+    monkeypatch.delenv("ACAGI_ELEVATED", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ACAGi.py",
+            "--workspace",
+            r"C:\\Program Files\\ACAGi Data",
+        ],
+    )
+
+    logger = logging.getLogger("test.elevation")
+    ensure_windows_elevation = _load_ensure_windows_elevation()
+
+    with pytest.raises(SystemExit) as excinfo:
+        ensure_windows_elevation(logger)
+
+    assert excinfo.value.code == 0
+    expected_params = subprocess.list2cmdline(
+        ["--workspace", r"C:\\Program Files\\ACAGi Data"]
+    )
+    assert captured["params"] == expected_params
+    assert captured["args"][1] == "runas"

--- a/logs/session_2025-10-19.md
+++ b/logs/session_2025-10-19.md
@@ -1,0 +1,31 @@
+# Session Log — 2025-10-19
+
+## Objective
+- Address Windows elevation relaunch quoting bug in ACAGi.py.
+- Add Windows-only unit test to verify argument preservation.
+- Document change in CHANGELOG.md.
+
+## Context
+- Branch `work` without remote tracking; origin/main unavailable locally.
+- `_ensure_windows_elevation` currently assembles relaunch command without robust quoting for spaced arguments.
+
+## Notes from Canonical Artifacts
+- Agent manual mandates verbose documentation and session logging.
+- memory/logic_inbox.jsonl contains outstanding items unrelated to current task but notes pending manual smoke test for embedded Qt launch.
+
+## Suggested Next Coding Steps
+1. Inspect `_ensure_windows_elevation` implementation to determine current relaunch command construction.
+2. Update logic to leverage `subprocess.list2cmdline` for Windows quoting.
+3. Add Windows-only unit test ensuring spaced argument remains intact through relaunch.
+4. Update CHANGELOG entry summarizing quoting fix.
+5. Run available tests (note if platform limitations prevent Windows-only test execution).
+
+## Unresolved Sub-Goals
+- Confirm whether existing test harness supports Windows-specific skips on non-Windows platforms.
+- Determine location for new unit test within repository.
+
+
+## Outcome
+- Replaced string-join relaunch parameters with `subprocess.list2cmdline` to keep quoting intact.
+- Added Windows-only unit test that compiles `_ensure_windows_elevation` in isolation and verifies spaced arguments are preserved.
+- Documented the change in `CHANGELOG.md` and noted testing constraints (skip on non-Windows).

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -125,7 +125,7 @@
     {
       "id": "task-bucket-serialization-discipline",
       "title": "Task Bucket Serialization Discipline",
-      "summary": "Task buckets advance through capture→note→bucketize→assemble→apply→test→verify→promote with Apply/Test/Verify serialized via file-touch leases so concurrent buckets do not race on shared paths.",
+      "summary": "Task buckets advance through capture\u2192note\u2192bucketize\u2192assemble\u2192apply\u2192test\u2192verify\u2192promote with Apply/Test/Verify serialized via file-touch leases so concurrent buckets do not race on shared paths.",
       "applies_to": "task-orchestration"
     },
     {
@@ -219,6 +219,12 @@
         "introduced": "2025-10-17",
         "notes": "Re-run `pip install PySide6` or leverage Codex_Terminal.py for CLI workflows when the guard triggers."
       }
+    },
+    {
+      "id": "acagi-isolated-function-testing",
+      "title": "Isolated Function Compilation for Tests",
+      "summary": "When unit testing ACAGi.py helpers, parse and compile the target function in isolation to avoid triggering heavy runtime dependency bootstrapping during import.",
+      "applies_to": "testing"
     }
   ],
   "procedures": [


### PR DESCRIPTION
## Summary
- switch `_ensure_windows_elevation` to `subprocess.list2cmdline` so elevated relaunches preserve spaced arguments
- add a Windows-only regression test that compiles the helper in isolation and asserts the quoted parameter survives the relaunch request
- document the fix in the changelog and capture the session/memory updates required by the workflow

## Testing
- `pytest Dev_Logic/tests/test_windows_elevation.py` *(skipped on linux)*

------
https://chatgpt.com/codex/tasks/task_e_68e0460c22d88328b482f00c5bebed62