### PR TITLE
feat: centralize python runtime selection

### DIFF
--- a/ACAGi.py
+++ b/ACAGi.py
@@ -11,6 +11,10 @@ Windows 10+ for the bridge runtime.
 
 from __future__ import annotations
 
+from tools.python_runtime import ensure_supported_python
+
+ensure_supported_python()
+
 import argparse
 import ast
 import audioop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 # Changelog
+## [0.1.40] - 2025-10-19
+### Added
+- Introduced `tools/python_runtime.py` to centralise supported interpreter
+  ranges, read optional overrides from environment variables or
+  `python-runtime.json`, and relaunch entry points when operators choose a
+  different executable.
+
+### Changed
+- Updated ACAGi, Codex Terminal, and automation scripts to invoke the shared
+  runtime check before importing heavy dependencies so every launcher obeys the
+  same interpreter policy.
+
+### Documentation
+- Documented the new Python runtime configuration workflow in `README.md` so
+  operators can adjust interpreter paths or version ranges without editing
+  scripts.
+
+### Validation
+- `python -m compileall ACAGi.py Codex_Terminal.py tools`
+
 ## [0.1.39] - 2025-10-18
 ### Added
 - Implemented an import-time dependency bootstrapper that auto-installs

--- a/Codex_Terminal.py
+++ b/Codex_Terminal.py
@@ -18,6 +18,10 @@ Requires: PySide6>=6.6, requests, Pillow (optional), local ollama, Windows 10+ f
 
 from __future__ import annotations
 
+from tools.python_runtime import ensure_supported_python
+
+ensure_supported_python()
+
 # --- DPI policy MUST be set before QApplication is created ---
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtCore import Qt

--- a/README.md
+++ b/README.md
@@ -50,6 +50,32 @@ cd ACAGi.py
 pip install -r requirements.txt
 ```
 
+### Python runtime configuration
+
+ACAGi entry points now validate the running interpreter before loading heavy
+dependencies.  By default the toolchain targets CPython 3.10–3.12.  Operators
+can steer launches to a specific interpreter without editing scripts in two
+ways:
+
+- Export ``ACAGI_PYTHON_INTERPRETER`` with the absolute path to the preferred
+  Python binary.
+- Create ``python-runtime.json`` inside the Codex agent config directory
+  (``Agent_Codex_Standalone/.codex_agent/config/`` by default) or point
+  ``ACAGI_PYTHON_RUNTIME_CONFIG`` at a custom location.  The JSON payload can
+  include ``python_interpreter``, ``min_version``, and ``max_version`` fields,
+  for example:
+
+  ```json
+  {
+    "python_interpreter": "/usr/local/bin/python3.11",
+    "min_version": "3.10",
+    "max_version": "3.12"
+  }
+  ```
+
+When a mismatch is detected ACAGi relaunches itself using the configured
+interpreter, keeping all entry points aligned with the shared policy.
+
 ## Usage
 
 ### Self-Implementation Mode

--- a/logs/session_2025-10-19.md
+++ b/logs/session_2025-10-19.md
@@ -1,0 +1,33 @@
+# Session 2025-10-19
+
+## Objective
+- Implement a shared Python runtime configuration helper and ensure every launcher validates interpreter compatibility while documenting the new knob.
+
+## Internal Prompt
+- "Create a central python_runtime helper that tracks supported version ranges and optional interpreter overrides, have entrypoints consult it at startup to relaunch if necessary, and update the README plus changelog with operator guidance."
+
+## Context
+- Repository has no configured remotes; documented failure of `git diff origin/main...HEAD` in prior session log persists.
+- Reviewed `AGENT.md`, `memory/codex_memory.json`, and the outstanding inbox item `2025-10-18-001` noting the need to smoke test embedded Qt launch scenarios.
+- No AGENTS.md files beyond the root manual; default repository-wide coding standards apply.
+
+## File Notes
+- `tools/python_runtime.py`: Added shared interpreter policy helper that tracks
+  supported version bounds, reads JSON/environment overrides, and relaunches the
+  process via `os.execv` with loop guards.
+- `ACAGi.py`, `Codex_Terminal.py`, `tools/logic_inbox.py`, `tools/codex_pr_sentinel.py`:
+  Imported the runtime helper ahead of heavy imports so every launcher enforces
+  the same interpreter selection policy.
+- `README.md`: Documented environment variables and JSON configuration operators
+  can use to customise the interpreter path or version window.
+- `CHANGELOG.md`: Logged the runtime helper addition and recorded the planned
+  `python -m compileall` validation run.
+
+## Validation
+- `python -m compileall ACAGi.py Codex_Terminal.py tools`
+
+## Suggested Next Coding Steps
+1. Design `tools/python_runtime.py` to expose supported version ranges and override resolution (env/config file).
+2. Update `ACAGi.py`, `Codex_Terminal.py`, and any other entrypoints to enforce runtime validation and optional relaunching.
+3. Document the new configuration knob in `README.md` and log the work in `CHANGELOG.md`.
+4. Consider whether additional entrypoints require similar validation or tests.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -125,7 +125,7 @@
     {
       "id": "task-bucket-serialization-discipline",
       "title": "Task Bucket Serialization Discipline",
-      "summary": "Task buckets advance through capture→note→bucketize→assemble→apply→test→verify→promote with Apply/Test/Verify serialized via file-touch leases so concurrent buckets do not race on shared paths.",
+      "summary": "Task buckets advance through capture\u2192note\u2192bucketize\u2192assemble\u2192apply\u2192test\u2192verify\u2192promote with Apply/Test/Verify serialized via file-touch leases so concurrent buckets do not race on shared paths.",
       "applies_to": "task-orchestration"
     },
     {
@@ -219,6 +219,12 @@
         "introduced": "2025-10-17",
         "notes": "Re-run `pip install PySide6` or leverage Codex_Terminal.py for CLI workflows when the guard triggers."
       }
+    },
+    {
+      "id": "python-runtime-selection",
+      "title": "Python Runtime Selection",
+      "summary": "All launchers import tools.python_runtime.ensure_supported_python to validate interpreter versions, honour ACAGI_PYTHON_INTERPRETER, and relaunch via python-runtime.json overrides before heavy imports.",
+      "applies_to": "python-runtime"
     }
   ],
   "procedures": [

--- a/tools/codex_pr_sentinel.py
+++ b/tools/codex_pr_sentinel.py
@@ -6,6 +6,10 @@ code paths, and deterministic output so that future maintainers understand the
 system without guesswork.
 """
 
+from tools.python_runtime import ensure_supported_python
+
+ensure_supported_python()
+
 import argparse
 import json
 import logging

--- a/tools/logic_inbox.py
+++ b/tools/logic_inbox.py
@@ -1,5 +1,9 @@
 """Utilities for maintaining the Codex logic inbox and memory schema."""
 
+from tools.python_runtime import ensure_supported_python
+
+ensure_supported_python()
+
 import argparse
 import json
 import logging

--- a/tools/python_runtime.py
+++ b/tools/python_runtime.py
@@ -1,0 +1,301 @@
+"""Shared helpers for enforcing the supported Python interpreter runtime.
+
+This module provides a centralised place to describe the Python versions the
+ACAGi toolchain supports and the optional interpreter override operators can
+configure.  Entry points import :func:`ensure_supported_python` before touching
+heavy dependencies so version checks and relaunch logic occur consistently.
+
+Configuration hierarchy (highest precedence first):
+
+* ``ACAGI_PYTHON_INTERPRETER`` environment variable – absolute path to the
+  preferred interpreter.
+* ``ACAGI_PYTHON_RUNTIME_CONFIG`` environment variable – path to a JSON file
+  mirroring the default configuration schema.
+* ``<workspace>/.codex_agent/config/python-runtime.json`` – persistent config
+  co-located with other Codex agent assets; the file is optional.
+
+The JSON schema accepts ``{"python_interpreter": "/path/to/python",
+"min_version": "3.10", "max_version": "3.12"}``.  Missing entries fall back to
+repository defaults.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, MutableMapping, Optional, Sequence, Tuple
+
+LOGGER = logging.getLogger("acagi.python_runtime")
+
+SUPPORTED_MIN_VERSION: Tuple[int, int, int] = (3, 10, 0)
+SUPPORTED_MAX_VERSION: Tuple[int, int, int] = (3, 12, 99)
+DEFAULT_CONFIG_FILENAME = "python-runtime.json"
+CONFIG_RELATIVE_PATH = Path(".codex_agent") / "config" / DEFAULT_CONFIG_FILENAME
+ENV_INTERPRETER = "ACAGI_PYTHON_INTERPRETER"
+ENV_CONFIG_PATH = "ACAGI_PYTHON_RUNTIME_CONFIG"
+ENV_RELAUNCHED = "ACAGI_RUNTIME_RELAUNCHED"
+
+
+@dataclass(frozen=True, slots=True)
+class PythonRuntimeConfig:
+    """Resolved interpreter configuration for the active process."""
+
+    min_version: Tuple[int, int, int]
+    max_version: Tuple[int, int, int]
+    interpreter_path: Optional[Path]
+
+    def is_version_supported(self, version: Tuple[int, int, int]) -> bool:
+        """Return ``True`` when ``version`` falls within the configured bounds."""
+
+        return self.min_version <= version <= self.max_version
+
+
+def ensure_supported_python(argv: Optional[Sequence[str]] = None) -> None:
+    """Validate the running interpreter and relaunch if overrides dictate.
+
+    The helper exits early when the active interpreter matches both the
+    supported version range and the configured executable.  When a mismatch is
+    detected, the function relaunches the process using :func:`os.execv` where
+    possible or spawns a subprocess as a fallback.
+    """
+
+    config = _load_config()
+    current_version = _version_tuple(sys.version_info)
+    current_executable = Path(sys.executable).resolve()
+    argv = tuple(sys.argv if argv is None else argv)
+
+    if not config.is_version_supported(current_version):
+        _handle_version_mismatch(config, current_version, current_executable, argv)
+
+    if config.interpreter_path is None:
+        return
+
+    desired_executable = config.interpreter_path
+    if _paths_equal(desired_executable, current_executable):
+        return
+
+    if _should_skip_relaunch(desired_executable):
+        LOGGER.debug(
+            "Detected relaunch loop guard for interpreter %s; continuing with %s",
+            desired_executable,
+            current_executable,
+        )
+        return
+
+    _relaunch(desired_executable, argv)
+
+
+def _handle_version_mismatch(
+    config: PythonRuntimeConfig,
+    version: Tuple[int, int, int],
+    executable: Path,
+    argv: Sequence[str],
+) -> None:
+    """React to a version mismatch according to the available overrides."""
+
+    desired = config.interpreter_path
+    version_repr = _format_version(version)
+    supported_repr = (
+        f"{config.min_version[0]}.{config.min_version[1]}"
+        f"–{config.max_version[0]}.{config.max_version[1]}"
+    )
+
+    if desired is not None and not _paths_equal(desired, executable):
+        LOGGER.warning(
+            "Python %s falls outside the supported range %s; relaunching via %s",
+            version_repr,
+            supported_repr,
+            desired,
+        )
+        _relaunch(desired, argv)
+
+    message = (
+        "ACAGi requires a Python interpreter within the supported range "
+        f"{supported_repr}. Current runtime reports {version_repr} at "
+        f"{executable}. Configure an override via {ENV_INTERPRETER} or the "
+        "python-runtime.json configuration file."
+    )
+    raise RuntimeError(message)
+
+
+def _load_config() -> PythonRuntimeConfig:
+    """Resolve interpreter overrides from the environment and config files."""
+
+    min_version = SUPPORTED_MIN_VERSION
+    max_version = SUPPORTED_MAX_VERSION
+    interpreter = _read_interpreter_override()
+
+    config_path = _discover_config_path()
+    payload: Mapping[str, object] = {}
+    if config_path is not None and config_path.exists():
+        try:
+            payload = _read_json(config_path)
+        except Exception:
+            LOGGER.exception("Failed to parse python runtime config: %s", config_path)
+
+    if payload:
+        min_version = _coerce_version(payload.get("min_version"), fallback=min_version)
+        max_version = _coerce_version(payload.get("max_version"), fallback=max_version)
+        if interpreter is None:
+            interpreter_value = payload.get("python_interpreter")
+            interpreter = _coerce_path(interpreter_value)
+
+    config = PythonRuntimeConfig(
+        min_version=min_version,
+        max_version=max_version,
+        interpreter_path=interpreter,
+    )
+
+    return config
+
+
+def _discover_config_path() -> Optional[Path]:
+    """Return the config path described by environment variables or defaults."""
+
+    explicit = os.environ.get(ENV_CONFIG_PATH, "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+
+    workspace_override = os.environ.get("CODEX_WORKSPACE", "").strip()
+    if workspace_override:
+        workspace = Path(workspace_override).expanduser()
+    else:
+        workspace = _default_workspace()
+    return workspace / CONFIG_RELATIVE_PATH
+
+
+def _default_workspace() -> Path:
+    """Mirror ACAGi's default workspace resolution for config discovery."""
+
+    return _script_root() / "Agent_Codex_Standalone"
+
+
+def _script_root() -> Path:
+    """Directory containing repository entry points (ACAGi.py, Codex_Terminal.py)."""
+
+    return Path(__file__).resolve().parent.parent
+
+
+def _read_interpreter_override() -> Optional[Path]:
+    """Extract the interpreter override path from the environment."""
+
+    candidate = os.environ.get(ENV_INTERPRETER, "").strip()
+    if not candidate:
+        return None
+    return _coerce_path(candidate)
+
+
+def _coerce_path(value: object) -> Optional[Path]:
+    """Convert ``value`` into a resolved :class:`Path` when possible."""
+
+    if isinstance(value, (str, Path)):
+        try:
+            return Path(value).expanduser().resolve()
+        except OSError:
+            return Path(value).expanduser()
+    return None
+
+
+def _coerce_version(value: object, *, fallback: Tuple[int, int, int]) -> Tuple[int, int, int]:
+    """Normalise version inputs like ``"3.10"`` or ``[3, 11, 2]`` into tuples."""
+
+    if isinstance(value, str):
+        parts = value.split(".")
+    elif isinstance(value, Sequence):
+        parts = [str(item) for item in value]
+    else:
+        return fallback
+
+    numbers: list[int] = []
+    for part in parts:
+        if not part:
+            continue
+        try:
+            numbers.append(int(part))
+        except ValueError:
+            return fallback
+        if len(numbers) == 3:
+            break
+
+    if not numbers:
+        return fallback
+
+    while len(numbers) < 3:
+        numbers.append(0)
+
+    return tuple(numbers[:3])  # type: ignore[return-value]
+
+
+def _read_json(path: Path) -> Mapping[str, object]:
+    """Load JSON payload from ``path`` with informative logging."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        try:
+            data = json.load(handle)
+        except json.JSONDecodeError as exc:
+            LOGGER.warning("Invalid JSON in %s: %s", path, exc)
+            return {}
+    if not isinstance(data, Mapping):
+        LOGGER.warning("Python runtime config %s did not contain a mapping", path)
+        return {}
+    return data
+
+
+def _version_tuple(info: sys.version_info) -> Tuple[int, int, int]:
+    """Normalise :data:`sys.version_info` for tuple comparisons."""
+
+    return info.major, info.minor, info.micro
+
+
+def _format_version(version: Tuple[int, int, int]) -> str:
+    """Render a human-readable version string."""
+
+    major, minor, micro = version
+    return f"{major}.{minor}.{micro}"
+
+
+def _paths_equal(first: Path, second: Path) -> bool:
+    """Return ``True`` when two filesystem paths reference the same target."""
+
+    try:
+        return first.resolve() == second.resolve()
+    except OSError:
+        return first == second
+
+
+def _should_skip_relaunch(desired: Path) -> bool:
+    """Guard against relaunch loops when the target interpreter re-invokes us."""
+
+    recorded = os.environ.get(ENV_RELAUNCHED)
+    if not recorded:
+        return False
+    try:
+        recorded_path = Path(recorded).resolve()
+    except OSError:
+        recorded_path = Path(recorded)
+    try:
+        desired_path = desired.resolve()
+    except OSError:
+        desired_path = desired
+    return recorded_path == desired_path
+
+
+def _relaunch(executable: Path, argv: Sequence[str]) -> None:
+    """Replace the current process with ``executable`` preserving arguments."""
+
+    os.environ[ENV_RELAUNCHED] = str(executable)
+    command = [str(executable), *argv]
+    LOGGER.info("Relaunching process via %s", executable)
+    try:
+        os.execv(str(executable), command)
+    except OSError:
+        LOGGER.debug("os.execv failed; falling back to subprocess", exc_info=True)
+        env: MutableMapping[str, str] = dict(os.environ)
+        result = subprocess.call(command, env=env)
+        raise SystemExit(result)
+    raise SystemExit(0)


### PR DESCRIPTION
## Summary
- add a shared tools/python_runtime helper that records supported Python ranges and resolves interpreter overrides from env/config
- ensure ACAGi, Codex_Terminal, and automation scripts invoke the helper before importing heavy modules
- document the new configuration workflow in README/CHANGELOG and capture the lesson in session logs and memory

## Testing
- python -m compileall ACAGi.py Codex_Terminal.py tools

## Risk
- Low; affects interpreter bootstrap logic and docs

## Next Steps
- Consider adding automated coverage for python-runtime.json parsing to lock in edge cases


------
https://chatgpt.com/codex/tasks/task_e_68e027e0093c8328adccaf0eef4d647a