### PR TITLE
feat: bundle codex theme asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## [0.1.42] - 2025-10-21
+### Added
+- Bundled the Codex Terminal `advanced_styles.json` under `Styles/` so ACAGi.py and Codex_Terminal.py launch with the shared bright-blue desktop theme by default.
+
+### Validation
+- `python -m compileall ACAGi.py Codex_Terminal.py`
+
 ## [0.1.41] - 2025-10-20
 ### Added
 - Introduced `tools/python_runtime.py`, a reusable helper that inspects

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ cd ACAGi.py
 pip install -r requirements.txt
 ```
 
+### Visual Theme Assets
+
+- The Codex Terminal palette ships in `Styles/advanced_styles.json`. Both `ACAGi.py` and `Codex_Terminal.py` load this file on startup so the desktop launches with the bright-blue Codex gradient without additional setup.
+
 ### Pinning the Python Interpreter
 
 All entrypoints now import `tools.python_runtime.ensure_desired_interpreter()`

--- a/Styles/advanced_styles.json
+++ b/Styles/advanced_styles.json
@@ -1,0 +1,22 @@
+{
+  "desktop_top": "#0f58ff",
+  "desktop_mid": "#2f7cff",
+  "desktop_edge_glow": "#70c3ff",
+  "card_bg": "#0e1624",
+  "card_border": "#2B3B4C",
+  "card_radius": 12,
+  "header_bg": "#111b2b",
+  "header_text": "#eaf2ff",
+  "user_bubble": "#0d3a84",
+  "user_text": "#eaf2ff",
+  "ai_bubble": "#0f1a2d",
+  "ai_text": "#ffffff",
+  "think_text": "#6fb2b2",
+  "model_name": "#00a7a7",
+  "accent": "#1E5AFF",
+  "accent_hover": "#2f72ff",
+  "muted": "#1c2a3b",
+  "live_ok": "#00d17a",
+  "live_warn": "#ffb300",
+  "live_err": "#ff3b30"
+}

--- a/logs/session_2025-10-03.md
+++ b/logs/session_2025-10-03.md
@@ -152,3 +152,32 @@
 
 ### TODO Mirror
 - Pending logic inbox items remain unchanged; revisit `2025-10-18-002` after implementing shared helper logic to decide if it can be marked addressed.
+
+---
+# Session Log — 2025-10-03 (Style Parity)
+
+## Objective
+- Ensure the primary ACAGi launcher renders with the same visual styling as Codex_Terminal.
+- Capture context from governance artifacts and prior logs before modifying UI assets.
+- Plan validation to confirm theme parity without a runnable GUI in the container.
+
+## Context Snapshot
+- Branch: `work` (no upstream remote configured).
+- `git status`: clean at session start (chunk eb77d7).
+- `git log -n 10 --oneline`: captured recent history (chunk 06b7b4).
+- `git diff origin/main...HEAD`: unavailable because `origin/main` does not exist (chunk ee67d4).
+- Runtime GUI dependencies (PySide6, etc.) are not installed in the container; styling changes must be validated via static inspection.
+
+## Notes from Canonical Artifacts
+- `AGENT.md` mandates verbose intent logging, CHANGELOG updates, and reuse of shared helpers for desktop boot flows.
+- `memory/codex_memory.json` emphasises monolithic ownership of UI components within ACAGi.py and reuse of shared helpers across entrypoints.
+- `memory/logic_inbox.jsonl` lists outstanding items unrelated to style parity but flags an upcoming embedded Qt smoke test that should remain unaffected.
+
+## Suggested Next Coding Steps
+1. Inspect ACAGi.py and Codex_Terminal.py theme loaders to identify where shared style assets should live.
+2. Introduce a repository-tracked `Styles/advanced_styles.json` so both entrypoints resolve the same theme file without manual setup.
+3. Update CHANGELOG and documentation to reflect the new bundled style asset and add static validation (e.g., `python -m compileall`).
+
+## Unresolved Sub-Goals
+- Future enhancement: factor shared theme definitions into a dedicated helper to reduce duplication across entrypoints.
+- Confirm on a real workstation that the bundled JSON restores Codex Terminal gradients when PySide6 is available.

--- a/memory/codex_memory.json
+++ b/memory/codex_memory.json
@@ -235,6 +235,16 @@
         "introduced": "2025-10-20",
         "notes": "Operators can pin a runtime via environment variables, python_runtime.json, or python_runtime.ini inside .codex_agent/config."
       }
+    },
+    {
+      "id": "codex-style-asset",
+      "title": "Bundled Codex Style Asset",
+      "summary": "Styles/advanced_styles.json now ships with the repository so ACAGi.py and Codex_Terminal.py share the same bright-blue desktop theme without manual setup.",
+      "applies_to": "ui-theme",
+      "metadata": {
+        "introduced": "2025-10-21",
+        "notes": "Keep the JSON in sync with Theme defaults or future palette updates to avoid regressions across entrypoints."
+      }
     }
   ],
   "procedures": [

--- a/memory/logic_inbox.jsonl
+++ b/memory/logic_inbox.jsonl
@@ -7,3 +7,4 @@
 {"id": "2025-10-18-001", "title": "Smoke test embedded Qt launch path", "status": "new", "notes": "Manually launch ACAGi from a host already running QApplication to verify the early-return log and ensure no duplicate windows spawn."}
 {"id": "2025-10-18-002", "title": "Factor Qt bootstrap helper", "status": "completed", "notes": "Codex_Terminal now imports the guarded helper from ACAGi.py and invokes it immediately before QApplication startup."}
 {"id": "2025-10-20-001", "title": "Document interpreter normalization workflow", "status": "completed", "notes": "README explains ACAGI_PYTHON_* overrides and workspace config files; entry scripts import tools.python_runtime to enforce the selected interpreter."}
+{"id": "2025-10-03-004", "title": "Factor shared theme helper", "status": "new", "notes": "Extract the Theme dataclass and style loaders into a reusable module so Codex_Terminal and ACAGi.py stay in lockstep without duplicating definitions."}


### PR DESCRIPTION
## Summary
- add the shared `Styles/advanced_styles.json` palette so ACAGi.py and Codex_Terminal.py launch with identical Codex styling
- document the bundled asset in README, CHANGELOG, session logs, memory, and logic inbox for governance traceability

## Testing
- `python -m compileall ACAGi.py Codex_Terminal.py`

## Risk
- Low: ships a static JSON palette; requires manual verification on a workstation with PySide6 to confirm gradients load as expected.

## Next Steps
- Track the new logic-inbox item to factor the shared Theme helper into a reusable module.


------
https://chatgpt.com/codex/tasks/task_e_68e05213b7848328978f9f8c5e1e9e7b